### PR TITLE
LIMS-2480 Fix issues filtering and sorting batch folder listing

### DIFF
--- a/bika/lims/browser/batchfolder.py
+++ b/bika/lims/browser/batchfolder.py
@@ -40,12 +40,15 @@ class BatchFolderContentsView(BikaListingView):
         self.pagesize = 25
 
         self.columns = {
-            'Title': {'title': _('Title')},
-            'BatchID': {'title': _('Batch ID')},
+            'Title': {'title': _('Title'),
+                      'index': 'sortable_title'},
+            'BatchID': {'title': _('Batch ID'), 'index': 'BatchID'},
             'Description': {'title': _('Description')},
-            'BatchDate': {'title': _('Date')},
-            'Client': {'title': _('Client')},
-            'state_title': {'title': _('State'), 'sortable': False},
+            'BatchDate': {'title': _('Date'), 'index': 'BatchDate'},
+            'Client': {'title': _('Client'), 'index': 'getClientTitle'},
+            'state_title': {'title': _('State'),
+                            'index': 'review_state',
+                            'sortable': False},
         }
 
         self.review_states = [  # leave these titles and ids alone

--- a/bika/lims/browser/client/views/batches.py
+++ b/bika/lims/browser/client/views/batches.py
@@ -13,15 +13,5 @@ class ClientBatchesView(BatchFolderContentsView):
         self.view_url = self.context.absolute_url() + "/batches"
 
     def __call__(self):
+        self.contentFilter['getClientTitle'] = self.context.Title()
         return BatchFolderContentsView.__call__(self)
-
-    def contentsMethod(self, contentFilter):
-        bc = getToolByName(self.context, "bika_catalog")
-        batches = {}
-        for ar in bc(portal_type='AnalysisRequest',
-                     getClientUID=self.context.UID()):
-            ar = ar.getObject()
-            batch = ar.getBatch()
-            if batch is not None:
-                batches[batch.UID()] = batch
-        return batches.values()

--- a/bika/lims/setuphandlers.py
+++ b/bika/lims/setuphandlers.py
@@ -616,6 +616,7 @@ class BikaGenerator:
         addIndex(bc, 'getAnalysisService', 'KeywordIndex')
         addIndex(bc, 'getAnalyst', 'FieldIndex')
         addIndex(bc, 'getAnalysts', 'KeywordIndex')
+        addIndex(bc, 'BatchID', 'FieldIndex', 'getBatchID')
         addIndex(bc, 'BatchDate', 'DateIndex')
         addIndex(bc, 'getClientOrderNumber', 'FieldIndex')
         addIndex(bc, 'getClientReference', 'FieldIndex')

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,5 +1,6 @@
 3.2.1 (unreleased)
 ------------------
+LIMS-2480: Fix issues with sorting and filtering when viewing Batches
 LIMS-1391: Add configurable identifier types (CAS# for AnalysisService)
 LIMS-2357: Custom Landing Page and Link to switch between the Front Page and Dashboard
 LIMS-2341: Cleanup and format default Multi-AR COA


### PR DESCRIPTION
Simply added missing indexes (and sort-index for BatchID)