### PR TITLE
LIMS-2333 Added to context/path to search query on ajax call

### DIFF
--- a/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add_by_col.js
@@ -398,6 +398,8 @@ function AnalysisRequestAddByCol() {
         uids = [uid, $("#bika_setup").attr("bika_samplepoints_uid")]
         element = $("tr[fieldname=SamplePoint] td[arnum=" + arnum + "] input")[0]
         filter_combogrid(element, "getClientUID", uids)
+        element = $("tr[fieldname=Sample] td[arnum=" + arnum + "] input")[0]
+        filter_combogrid(element, "getClientUID", uids)
         uids = [uid, $("#bika_setup").attr("bika_artemplates_uid")]
         element = $("tr[fieldname=Template] td[arnum=" + arnum + "] input")[0]
         filter_combogrid(element, "getClientUID", uids)

--- a/bika/lims/browser/widgets/referencewidget.py
+++ b/bika/lims/browser/widgets/referencewidget.py
@@ -192,10 +192,6 @@ class ajaxReferenceWidgetSearch(BrowserView):
         rows = []
 
         brains = []
-        self.request['search_query'] = json.dumps(
-                {'path' : {"query": 
-                            '/'.join(self.context.getPhysicalPath()) }
-                })
         for name, adapter in getAdapters((self.context, self.request), IReferenceWidgetVocabulary):
             brains.extend(adapter())
 

--- a/bika/lims/browser/widgets/referencewidget.py
+++ b/bika/lims/browser/widgets/referencewidget.py
@@ -192,6 +192,10 @@ class ajaxReferenceWidgetSearch(BrowserView):
         rows = []
 
         brains = []
+        self.request['search_query'] = json.dumps(
+                {'path' : {"query": 
+                            '/'.join(self.context.getPhysicalPath()) }
+                })
         for name, adapter in getAdapters((self.context, self.request), IReferenceWidgetVocabulary):
             brains.extend(adapter())
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
All Samples are listed for a client should only list its own
https://jira.bikalabs.com/browse/LIMS-2333

## Current behavior before PR
    On AR Add samples: all samples for all clients are shown 
## Desired behavior after PR is merged 
    Should only list samples that belong to the current client
--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1] https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2] https://www.python.org/dev/peps/pep-0008
