### PR TITLE
LIMS-2564 Hiding RH Column on ARImport screens

### DIFF
--- a/bika/lims/content/arimport.py
+++ b/bika/lims/content/arimport.py
@@ -39,6 +39,7 @@ from Products.DataGridField import LinesColumn
 from Products.DataGridField import SelectColumn
 from Products.DataGridField import TimeColumn
 from plone import api
+from plone.portlets.interfaces import ILocalPortletAssignable
 from plone.indexer import indexer
 from zope import event
 from zope.event import notify
@@ -261,7 +262,7 @@ class ARImport(BaseFolder):
     security = ClassSecurityInfo()
     schema = schema
     displayContentsTab = False
-    implements(IARImport)
+    implements(IARImport, ILocalPortletAssignable)
 
     _at_rename_after_creation = True
 

--- a/bika/lims/profiles/default/metadata.xml
+++ b/bika/lims/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <metadata>
-  <version>320</version>
+  <version>3201</version>
   <dependencies>
     <dependency>profile-jarn.jsi18n:default</dependency>
     <dependency>profile-Products.ATExtensions:default</dependency>

--- a/bika/lims/subscribers/blockPortletOnARImport.py
+++ b/bika/lims/subscribers/blockPortletOnARImport.py
@@ -1,0 +1,15 @@
+from zope.component import getMultiAdapter, getUtility
+from plone.portlets.interfaces import IPortletManager
+from plone.portlets.interfaces import ILocalPortletAssignmentManager
+from plone.portlets.constants import USER_CATEGORY
+from plone.portlets.constants import GROUP_CATEGORY
+from plone.portlets.constants import CONTENT_TYPE_CATEGORY
+from plone.portlets.constants import CONTEXT_CATEGORY
+
+#The object/content has to have ILocalPortletAssignable interface implemented
+#if it does not already have it so that you don't get a ComponentLookupError
+def blockPortletsUpponARImportCreation(content, event):
+    manager = getUtility(IPortletManager, name='plone.rightcolumn')
+    assignable = getMultiAdapter((content, manager), ILocalPortletAssignmentManager)
+    for category in (GROUP_CATEGORY, CONTENT_TYPE_CATEGORY,CONTEXT_CATEGORY,USER_CATEGORY):
+        assignable.setBlacklistStatus(category, 1)

--- a/bika/lims/subscribers/configure.zcml
+++ b/bika/lims/subscribers/configure.zcml
@@ -60,5 +60,9 @@
       for="Products.PluggableAuthService.interfaces.events.IUserLoggedInEvent"
       handler="bika.lims.subscribers.dep_cookie.SetDepartmentCookies"
       />
-
+  <subscriber
+      for="bika.lims.interfaces.IARImport
+           zope.app.container.interfaces.IObjectAddedEvent"
+      handler="bika.lims.subscribers.blockPortletOnARImport.blockPortletsUpponARImportCreation"
+      />
 </configure>

--- a/bika/lims/upgrade/configure.zcml
+++ b/bika/lims/upgrade/configure.zcml
@@ -578,4 +578,13 @@
          handler="bika.lims.upgrade.to320.upgrade"
          sortkey="1"
          profile="bika.lims:default"/>
+
+ <genericsetup:upgradeStep
+         title="Disabling Right Column On ARImport's View"
+         description=""
+         source="3201"
+         destination="3201"
+         handler="bika.lims.upgrade.to3201.upgrade"
+         sortkey="1"
+         profile="bika.lims:default"/>
 </configure>

--- a/bika/lims/upgrade/to3201.py
+++ b/bika/lims/upgrade/to3201.py
@@ -1,0 +1,47 @@
+# This file is part of Bika LIMS
+#
+# Copyright 2011-2016 by it's authors.
+# Some rights reserved. See LICENSE.txt, AUTHORS.txt.
+
+from Acquisition import aq_inner
+from Acquisition import aq_parent
+
+import transaction
+from Products.CMFCore.utils import getToolByName
+from Products.CMFPlone.utils import _createObjectByType
+from Products.ZCatalog.Catalog import CatalogError
+
+from bika.lims import logger
+from Products.CMFCore import permissions
+from Products.CMFPlone.utils import _createObjectByType
+from bika.lims.utils import tmpID
+from bika.lims.permissions import *
+from bika.lims.utils import tmpID
+from plone import api
+from bika.lims.interfaces import IARImport, IAnalysisRequest
+
+
+from zope.component import getMultiAdapter, getUtility
+from plone.portlets.interfaces import IPortletManager
+from plone.portlets.interfaces import ILocalPortletAssignmentManager
+from plone.portlets.constants import USER_CATEGORY
+from plone.portlets.constants import GROUP_CATEGORY
+from plone.portlets.constants import CONTENT_TYPE_CATEGORY
+from plone.portlets.constants import CONTEXT_CATEGORY
+
+def upgrade(tool):
+    """Upgrade step required for Bika LIMS
+    """
+    disableRightColumnOnARImportView()
+
+    return True
+
+def disableRightColumnOnARImportView():
+    arimports = api.content.find(object_provides=IARImport.__identifier__)
+    for arimport in arimports:
+        obj = arimport.getObject()
+        manager = getUtility(IPortletManager, name='plone.rightcolumn')
+        assignable = getMultiAdapter((obj, manager), ILocalPortletAssignmentManager)
+        for category in (GROUP_CATEGORY, CONTENT_TYPE_CATEGORY,CONTEXT_CATEGORY,USER_CATEGORY):
+            assignable.setBlacklistStatus(category, 1)
+


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
Hiding of Right Hand Column on ARImport screens because it does not look good on small screens
https://jira.bikalabs.com/browse/LIMS-2564
https://github.com/bikalabs/bika.lims/issues/


## Current behavior before PR
     Right hand columns shows on the ARImport screen
## Desired behavior after PR is merged 
     Right hand column is disabled on the ARImport screen
--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
