### PR TITLE
Use AR as the context to retrieve the view.

### DIFF
--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -456,12 +456,12 @@ class AnalysisRequestPublishView(BrowserView):
                 attachment.absolute_url(), self.getDirection())
         return info
 
-    def _sorted_attachments(self, attachments):
+    def _sorted_attachments(self, ar, attachments=[]):
         """Sorter to return the attachments in the same order as the user
         defined in the attachments viewlet
         """
         inf = float("inf")
-        view = self.context.restrictedTraverse("attachments_view")
+        view = ar.restrictedTraverse("attachments_view")
         order = view.get_attachments_order()
 
         def att_cmp(att1, att2):
@@ -481,7 +481,7 @@ class AnalysisRequestPublishView(BrowserView):
                 continue
             attachments.append(self._get_attachment_info(attachment))
 
-        return self._sorted_attachments(attachments)
+        return self._sorted_attachments(ar, attachments)
 
     def _get_an_attachments(self, ar):
         attachments = []
@@ -491,7 +491,7 @@ class AnalysisRequestPublishView(BrowserView):
                 if attachment.getReportOption() == "i":
                     continue
                 attachments.append(self._get_attachment_info(attachment))
-        return self._sorted_attachments(attachments)
+        return self._sorted_attachments(ar, attachments)
 
     def _batch_data(self, ar):
         data = {}

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.3.0 (unreleased)
 ------------------
 
+- Issue-2173: Publishing multiple ARs fails
 - Issue-2132: Reorderable Attachments for Reports
 - Issue-2129: Migrate Attachments to blobs
 - Issue-2098: Inline rendered Attachments not in final PDF


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Please see https://github.com/bikalabs/bika.lims/issues/2173 for further details

## Current behavior before PR

Multi AR publication fails

## Desired behavior after PR is merged

Multi AR publication renders again.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
