### PR TITLE
Issue 1977: Workflow transition fails on catalog brains

### DIFF
--- a/bika/lims/workflow.py
+++ b/bika/lims/workflow.py
@@ -21,7 +21,7 @@ from zope.component import adapts
 from zope.interface import implementer
 from zope.interface import implements
 from zope.interface import Interface
-from plone import api
+from plone import api as ploneapi
 
 def skip(instance, action, peek=False, unskip=False):
     """Returns True if the transition is to be SKIPPED
@@ -97,7 +97,7 @@ def get_workflow_actions(obj):
     def translate(i):
         return t(PMF(i + "_transition_title"))
 
-    workflow = api.portal.get_tool("portal_workflow")
+    workflow = ploneapi.portal.get_tool("portal_workflow")
     actions = [{"id": it["id"],
                 "title": translate(it["id"])}
                for it in workflow.getTransitionsFor(obj)]
@@ -113,8 +113,8 @@ def isBasicTransitionAllowed(context, permission=None):
     normally be set in the guard_permission in workflow definition.
 
     """
-    workflow = api.portal.get_tool("portal_workflow")
-    mtool = api.portal.get_tool("portal_membership")
+    workflow = ploneapi.portal.get_tool("portal_workflow")
+    mtool = ploneapi.portal.get_tool("portal_membership")
     if workflow.getInfoFor(context, "cancellation_state", "") == "cancelled" \
             or workflow.getInfoFor(context, "inactive_state", "") == "inactive" \
             or (permission and mtool.checkPermission(permission, context)):
@@ -126,11 +126,11 @@ def getCurrentState(obj, stateflowid):
     """ The current state of the object for the state flow id specified
         Return empty if there's no workflow state for the object and flow id
     """
-    workflow = api.portal.get_tool("portal_workflow")
+    workflow = ploneapi.portal.get_tool("portal_workflow")
     return workflow.getInfoFor(obj, stateflowid, '')
 
 def getTransitionDate(obj, action_id):
-    workflow = api.portal.get_tool("portal_workflow")
+    workflow = ploneapi.portal.get_tool("portal_workflow")
     try:
         # https://jira.bikalabs.com/browse/LIMS-2242:
         # Sometimes the workflow history is inexplicably missing!
@@ -153,7 +153,7 @@ def getTransitionActor(obj, action_id):
     """Returns the identifier of the user who last performed the action
     on the object.
     """
-    workflow = api.portal.get_tool("portal_workflow")
+    workflow = ploneapi.portal.get_tool("portal_workflow")
     try:
         review_history = list(workflow.getInfoFor(obj, "review_history"))
         review_history.reverse()
@@ -219,7 +219,7 @@ def SamplePrepWorkflowChain(ob, wftool):
     """
     # use catalog to retrieve review_state: getInfoFor causes recursion loop
     chain = list(ToolWorkflowChain(ob, wftool))
-    bc = api.portal.get_tool('bika_catalog')
+    bc = ploneapi.portal.get_tool('bika_catalog')
     proxies = bc(UID=ob.UID())
     if not proxies or proxies[0].review_state != 'sample_prep':
         return chain
@@ -245,7 +245,7 @@ def SamplePrepTransitionEventHandler(instance, event):
 
     if not event.new_state.getTransitions():
         # Is this the final (No exit transitions) state?
-        workflow = api.portal.get_tool("portal_workflow")
+        workflow = ploneapi.portal.get_tool("portal_workflow")
         primary_wf_name = list(ToolWorkflowChain(instance, workflow))[0]
         primary_wf = workflow.getWorkflowById(primary_wf_name)
         primary_wf_states = primary_wf.states.keys()

--- a/bika/lims/workflow.py
+++ b/bika/lims/workflow.py
@@ -13,6 +13,7 @@ from bika.lims.jsonapi import get_include_fields
 from bika.lims.utils import changeWorkflowState
 from bika.lims.utils import t
 from bika.lims import logger
+from bika.lims import api
 from Products.CMFCore.interfaces import IContentish
 from Products.CMFCore.WorkflowCore import WorkflowException
 from Products.CMFPlone.interfaces import IWorkflowChain
@@ -52,10 +53,9 @@ def skip(instance, action, peek=False, unskip=False):
 def doActionFor(instance, action_id):
     actionperformed = False
     message = ''
-    workflow = api.portal.get_tool("portal_workflow")
     if not skip(instance, action_id, peek=True):
         try:
-            workflow.doActionFor(instance, action_id)
+            api.do_transition_for(instance, action_id)
             actionperformed = True
         except WorkflowException as e:
             message = str(e)

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,7 +1,7 @@
 3.2.1rc1 (unreleased)
 ---------------------
 
-- no changes yet
+- Issue-1977: AR can be transitioned to verified while all AS's remain to be verified
 
 
 3.2.1b3 (2017-08-07)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Please see https://github.com/bikalabs/bika.lims/issues/1977 for further details and screenshots.

## Current behavior before PR

Selecting the action menu in the upper right corner of an AR to trigger the `verify` transition set only the status of the AR to `verified`.

## Desired behavior after PR is merged

Contained Analyses are also in the `verified` state.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
