### PR TITLE
BC 74 Sample Workflow Broken

### DIFF
--- a/bika/lims/browser/client/workflow.py
+++ b/bika/lims/browser/client/workflow.py
@@ -83,15 +83,23 @@ class ClientWorkflowAction(AnalysisRequestWorkflowAction):
 
                 # grab this object's Sampler and DateSampled from the form
                 # (if the columns are available and edit controls exist)
+                Sampler = ''
+                DateSampled = ''
                 if 'getSampler' in form and 'getDateSampled' in form:
-                    Sampler = ''
                     if len(form['getSampler']) > 0 \
                             and form['getSampler'][0].get(obj_uid):
                         Sampler = form['getSampler'][0][obj_uid].strip()
-                    DateSampled = ''
                     if len(form['getDateSampled']) > 0 \
                             and form['getDateSampled'][0].get(obj_uid):
                         DateSampled = form['getDateSampled'][0][obj_uid].strip()
+
+                elif 'sample' in transitions \
+                        or 'getSampler' not in form \
+                        or 'getDateSampled' not in form:
+                    message = _('''Please display both Sampler and Date Sampled
+                                 columns''')
+                    self.context.plone_utils.addPortalMessage(message, 'error')
+
                 else:
                     continue
 

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.4.0 (unreleased)
 ------------------
 
+- Sampler and Sampling Date Columns are not validated when they are not displayed
 - Issue-2162: Added renameAfterCreation to partition creation in ARImport
 - Laboratory Supervisor field on the Laboratory(Bika Setup - Laboratory Information)
 - Laboratory License ID field on the Laboratory(Bika Setup - Laboratory Information)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://jira.bikalabs.com/browse/BC-74


## Current behavior before PR
      On the AR listing when the Sample button(transition) is clicked, Sampler and Date Sampled columns 
       show incorrect error message when they are hidden 
## Desired behavior after PR is merged
     To show correct error message for Sampler and Date Sampled columns when they are hidden and 
     the user is trying to Sample transition an AR

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
