### PR TITLE
Issue-2184: AR cloning takes too long on instances with many ASs

### DIFF
--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.2.1rc1 (unreleased)
 ---------------------
 
+- Issue-2184: AR Add 2 takes long to clone existing ARs on instances with many ASs
 - Issue-2178: Bika Listings are slow
 - Issue-1977: AR can be transitioned to verified while all AS's remain to be verified
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Please see https://github.com/bikalims/bika.lims/issues/2184 for further details

## Current behavior before PR

Cloning an existing AR with many selected Analyses takes more than 2 mins if the site contains many AnalysesServices. 

## Desired behavior after PR is merged

Cloning ARs is possible in an acceptable time.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
