### PR TITLE
Issue-2183-Recalculate-Show-Prices

### DIFF
--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1500,9 +1500,18 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
         return out
 
+    def show_recalculate_prices(self):
+        bika_setup = api.get_bika_setup()
+        return bika_setup.getShowPrices()
+
     def ajax_recalculate_prices(self):
         """Recalculate prices for all ARs
         """
+        # When the option "Include and display pricing information" in
+        # Bika Setup Accounting tab is not selected
+        if not self.show_recalculate_prices():
+            return {}
+
         # The sorted records from the request
         records = self.get_records()
 

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.4.0 (unreleased)
 ------------------
 
+- Issue-2183: Don't recalculate prices when option "Include and display pricing information" in Bika Setup Accounting is not selected
 - Sampler and Sampling Date Columns are not validated when they are not displayed
 - Issue-2162: Added renameAfterCreation to partition creation in ARImport
 - Laboratory Supervisor field on the Laboratory(Bika Setup - Laboratory Information)


### PR DESCRIPTION


## Description of the issue/feature this PR addresses

https://github.com/bikalabs/bika.lims/issues/2183


## Current behavior before PR
    function ajax_recalculate_prices is called even though the option 
    Include and display pricing information in BIka Setup, Accounting Tab is not selected 

## Desired behavior after PR is merged
     Prices must not be recalculated if  the Include and display pricing information option is not 
     selected

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
