### PR TITLE
AR Add 2: Prevent attempts to set missing fields

### DIFF
--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -382,6 +382,10 @@
       var $field, $parent, div, existing_uids, fieldname, img, me, mvl, portal_url, src, uids, uids_field;
       me = this;
       $field = $(field);
+      if (!$field.length) {
+        console.debug("field " + field + " does not exist, skip set_reference_field");
+        return;
+      }
       $parent = field.closest("div.field");
       fieldname = field.attr("name");
       console.debug("set_reference_field:: field=" + fieldname + " uid=" + uid + " title=" + title);

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -389,6 +389,11 @@ class window.AnalysisRequestAdd
 
     me = this
     $field = $(field)
+
+    # If the field doesn't exist in the form, avoid trying to set it's values
+    if ! $field.length
+      console.debug "field #{field} does not exist, skip set_reference_field"
+      return
     $parent = field.closest("div.field")
     fieldname = field.attr "name"
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

If an extension package has hidden fields from the AR-Add form, this can result in set_reference_field being called on missing fields.

## Current behavior before PR

AR Add form spinner appears when modifying some reference field (eg, the Sample Type field will cause this to happen if the DefaultContainerType field is hidden by an AT Schema Extender).  A message claiming that "existing_uids is not defined" appears in console.log, and the form cannot be submitted.

## Desired behavior after PR is merged

This little defensive check causes the function to return early if required field element is missing.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
