### PR TITLE
Backport/pr 2187 ar add reference fields

### DIFF
--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -382,6 +382,10 @@
       var $field, $parent, div, existing_uids, fieldname, img, me, mvl, portal_url, src, uids, uids_field;
       me = this;
       $field = $(field);
+      if (!$field.length) {
+        console.debug("field " + field + " does not exist, skip set_reference_field");
+        return;
+      }
       $parent = field.closest("div.field");
       fieldname = field.attr("name");
       console.debug("set_reference_field:: field=" + fieldname + " uid=" + uid + " title=" + title);

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -389,6 +389,11 @@ class window.AnalysisRequestAdd
 
     me = this
     $field = $(field)
+
+    # If the field doesn't exist in the form, avoid trying to set it's values
+    if ! $field.length
+      console.debug "field #{field} does not exist, skip set_reference_field"
+      return
     $parent = field.closest("div.field")
     fieldname = field.attr "name"
 

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -5,6 +5,10 @@
 - Issue-2178: Bika Listings are slow
 - Issue-1977: AR can be transitioned to verified while all AS's remain to be verified
 
+**Other Fixes**
+
+- AR Add form: Fixed reference field on omitted fields
+
 
 3.2.1b3 (2017-08-07)
 --------------------


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Backporting PR to 3.2.1 and 3.3.0

See PR https://github.com/bikalims/bika.lims/pull/2187 for details.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
