### PR TITLE
Issue-2004: Traceback when AS exponential format precision is None

### DIFF
--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.2.1rc1 (unreleased)
 ---------------------
 
+- Issue-2004: Traceback for AR when an Analysis is used w/o 'Exponential format precision' set
 - Issue-2184: AR Add 2 takes long to clone existing ARs on instances with many ASs
 - Issue-2178: Bika Listings are slow
 - Issue-1977: AR can be transitioned to verified while all AS's remain to be verified


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Please see Issue https://github.com/bikalims/bika.lims/issues/2004 for further details.


## Current behavior before PR

If the exponential format precision is empty (`None`), the following traceback occured:

```
Traceback (innermost last):
  Module ZPublisher.Publish, line 138, in publish
  Module ZPublisher.mapply, line 77, in mapply
  Module ZPublisher.Publish, line 48, in call_object
  Module bika.lims.browser.analysisrequest.view, line 93, in __call__
  Module bika.lims.browser.bika_listing, line 1058, in contents_table
  Module bika.lims.browser.bika_listing, line 1237, in __init__
  Module bika.lims.browser.analyses, line 621, in folderitems
  Module bika.lims.content.analysis, line 992, in getFormattedResult
  Module bika.lims.utils.analysis, line 300, in format_numeric_result
  Module bika.lims.utils.analysis, line 91, in _format_decimal_or_sci
TypeError: bad operand type for abs(): 'NoneType'
```

## Desired behavior after PR is merged

The field "Exponential Format Precision" is now required and if empty, the default value of `7` is returned.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
