### PR TITLE
Fixed Bika listing cache key to include the review_state

### DIFF
--- a/bika/lims/api.py
+++ b/bika/lims/api.py
@@ -876,11 +876,11 @@ def do_transition_for(brain_or_object, transition):
     :type brain_or_object: ATContentType/DexterityContentType/CatalogBrain
     :returns: The object where the transtion was performed
     """
+    if not isinstance(transition, basestring):
+        fail("Transition type needs to be string, got '%s'" % type(transition))
     obj = get_object(brain_or_object)
     # notify the BeforeTransitionEvent
     notify(BikaBeforeTransitionEvent(obj, transition))
-    if not isinstance(transition, basestring):
-        fail("Transition type needs to be string, got '%s'" % type(transition))
     try:
         ploneapi.content.transition(obj, transition)
     except ploneapi.exc.InvalidParameterError as e:

--- a/bika/lims/api.py
+++ b/bika/lims/api.py
@@ -715,6 +715,100 @@ def get_workflow_status_of(brain_or_object, state_var="review_state"):
     return workflow.getInfoFor(ob=obj, name=state_var)
 
 
+def get_creation_date(brain_or_object):
+    """Get the creation date of the brain or object
+
+    :param brain_or_object: A single catalog brain or content object
+    :type brain_or_object: ATContentType/DexterityContentType/CatalogBrain
+    :returns: Creation date
+    :rtype: DateTime
+    """
+    created = getattr(brain_or_object, "created", None)
+    if created is None:
+        fail("Object {} has no creation date ".format(
+             repr(brain_or_object)))
+    if callable(created):
+        return created()
+    return created
+
+
+def get_modification_date(brain_or_object):
+    """Get the modification date of the brain or object
+
+    :param brain_or_object: A single catalog brain or content object
+    :type brain_or_object: ATContentType/DexterityContentType/CatalogBrain
+    :returns: Modification date
+    :rtype: DateTime
+    """
+    modified = getattr(brain_or_object, "modified", None)
+    if modified is None:
+        fail("Object {} has no modification date ".format(
+             repr(brain_or_object)))
+    if callable(modified):
+        return modified()
+    return modified
+
+
+def get_review_status(brain_or_object):
+    """Get the `review_state` of an object
+
+    :param brain_or_object: A single catalog brain or content object
+    :type brain_or_object: ATContentType/DexterityContentType/CatalogBrain
+    :returns: Value of the review_status variable
+    :rtype: String
+    """
+    if is_brain(brain_or_object):
+        return brain_or_object.review_state
+    return get_workflow_status_of(brain_or_object, state_var="review_state")
+
+
+def get_cancellation_status(brain_or_object, default="active"):
+    """Get the `cancellation_state` of an object
+
+    :param brain_or_object: A single catalog brain or content object
+    :type brain_or_object: ATContentType/DexterityContentType/CatalogBrain
+    :returns: Value of the review_status variable
+    :rtype: String
+    """
+    if is_brain(brain_or_object):
+        return getattr(brain_or_object, "cancellation_state", default)
+    workflows = get_workflows_for(brain_or_object)
+    if 'bika_cancellation_workflow' not in workflows:
+        return default
+    return get_workflow_status_of(brain_or_object, 'cancellation_state')
+
+
+def get_inactive_status(brain_or_object, default="active"):
+    """Get the `cancellation_state` of an objct
+
+    :param brain_or_object: A single catalog brain or content object
+    :type brain_or_object: ATContentType/DexterityContentType/CatalogBrain
+    :returns: Value of the review_status variable
+    :rtype: String
+    """
+    if is_brain(brain_or_object):
+        return getattr(brain_or_object, "inactive_state", default)
+    workflows = get_workflows_for(brain_or_object)
+    if 'bika_inactive_workflow' not in workflows:
+        return default
+    return get_workflow_status_of(brain_or_object, 'inactive_state')
+
+
+def is_active(brain_or_object):
+    """Check if the workflow state of the object is 'inactive' or 'cancelled'.
+
+    :param brain_or_object: A single catalog brain or content object
+    :type brain_or_object: ATContentType/DexterityContentType/CatalogBrain
+    :returns: False if the object is in the state 'inactive' or 'cancelled'
+    :rtype: bool
+    """
+    if get_inactive_status(brain_or_object) == "inactive":
+        return False
+    if get_cancellation_status(brain_or_object) == "cancelled":
+        return False
+    return True
+
+
 def get_catalogs_for(brain_or_object, default="portal_catalog"):
     """Get all registered catalogs for the given portal_type, catalog brain or
     content object
@@ -755,33 +849,6 @@ def do_transition_for(brain_or_object, transition):
     obj = get_object(brain_or_object)
     ploneapi.content.transition(obj, transition)
     return obj
-
-
-def is_active(brain_or_object):
-    """Check if the workflow state of the object is 'inactive' or 'cancelled'.
-
-    :param brain_or_object: A single catalog brain or content object
-    :type brain_or_object: ATContentType/DexterityContentType/CatalogBrain
-    :returns: False if the object is in the state 'inactive' or 'cancelled'
-    :rtype: bool
-    """
-    if is_brain(brain_or_object):
-        if base_hasattr(brain_or_object, 'inactive_state') and \
-           brain_or_object.inactive_state == 'inactive':
-            return False
-        if base_hasattr(brain_or_object, 'cancellation_state') and \
-           brain_or_object.cancellation_state == 'cancelled':
-            return False
-    obj = get_object(brain_or_object)
-    wf = get_tool('portal_workflow')
-    workflows = get_workflows_for(obj)
-    if 'bika_inactive_workflow' in workflows \
-            and wf.getInfoFor(obj, 'inactive_state') == 'inactive':
-        return False
-    if 'bika_cancellation_workflow' in workflows \
-            and wf.getInfoFor(obj, 'cancellation_state') == 'cancelled':
-        return False
-    return True
 
 
 def get_roles_for_permission(permission, brain_or_object):
@@ -918,3 +985,21 @@ def get_current_user():
     :returns: Current User
     """
     return ploneapi.user.get_current()
+
+
+def make_cache_key_for(brain_or_object):
+    """Generate a good cache key for the given brain or object
+
+    :param brain_or_object: A single catalog brain or content object
+    :type brain_or_object: ATContentType/DexterityContentType/CatalogBrain
+    :returns: Cache Key
+    :rtype: str
+    """
+    key = [
+        get_portal_type(brain_or_object),
+        get_id(brain_or_object),
+        get_uid(brain_or_object),
+        # Return the microsecond since the epoch in GMT
+        get_modification_date(brain_or_object).micros(),
+    ]
+    return "-".join(map(lambda x: str(x), key))

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -44,11 +44,10 @@ from plone.memoize.volatile import DontCache
 
 
 def gen_key(brain):
-    obj = api.get_object(brain)
     portal_type = api.get_portal_type(brain)
     uid = api.get_uid(brain)
     state = brain.review_state
-    modified = obj.modified().ISO8601()
+    modified = brain.modified().ISO8601()
     return "{}-{}-{}-{}".format(portal_type, uid, state, modified)
 
 
@@ -57,7 +56,9 @@ def gen_ar_cache_key(brain):
     keys = []
     keys.append(gen_key(brain))
     for att in ar.getAttachment():
-        keys.append(gen_key(att))
+        keys.append("{}-{}".format(
+            api.get_uid(att),
+            att.modified().ISO8601()))
     for an in ar.getAnalyses():
         keys.append(gen_key(an))
     return "-".join(keys)

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -42,24 +42,6 @@ from plone.memoize.volatile import cache
 from plone.memoize.volatile import store_on_context
 
 
-def gen_ar_cache_key(brain_or_object):
-    ar = api.get_object(brain_or_object)
-    keys = []
-    keys.append(api.make_cache_key_for(ar))
-    for att in ar.getAttachment():
-        keys.append(api.make_cache_key_for(att))
-    for an in ar.getAnalyses():
-        keys.append(api.make_cache_key_for(an))
-    return "-".join(keys)
-
-
-def cache_key(method, self, brain_or_object):
-    portal_type = api.get_portal_type(brain_or_object)
-    if portal_type == "AnalysisRequest":
-        return gen_ar_cache_key(brain_or_object)
-    return api.make_cache_key_for(brain_or_object)
-
-
 class WorkflowAction:
     """ Workflow actions taken in any Bika contextAnalysisRequest context
 
@@ -890,7 +872,7 @@ class BikaListingView(BrowserView):
             return api.get_portal_type(obj)
         return fti.Title()
 
-    @cache(cache_key, store_on_context)
+    @cache(api.bika_cache_key_decorator, store_on_context)
     def make_listing_item(self, brain):
         """Returns an object dictionary suitable for the listing view
         """

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -44,10 +44,11 @@ from plone.memoize.volatile import DontCache
 
 
 def gen_key(brain):
+    obj = api.get_object(brain)
     portal_type = api.get_portal_type(brain)
     uid = api.get_uid(brain)
     state = brain.review_state
-    modified = brain.modified().ISO8601()
+    modified = obj.modified().ISO8601()
     return "{}-{}-{}-{}".format(portal_type, uid, state, modified)
 
 

--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -43,7 +43,7 @@ from plone.memoize.volatile import store_on_context
 
 
 def gen_ar_cache_key(brain_or_object):
-    ar = api.get_object(brain)
+    ar = api.get_object(brain_or_object)
     keys = []
     keys.append(api.make_cache_key_for(ar))
     for att in ar.getAttachment():

--- a/bika/lims/docs/API.rst
+++ b/bika/lims/docs/API.rst
@@ -1000,22 +1000,6 @@ A workflow transition should also change the cache key::
     True
 
 
-Creating a AR Cache Key
------------------------
-
-This function creates a cache key for AnalysisRequests only and generates a more
-sophisticated cache key for this content type::
-
-    >>> # TODO: api.get_ar_cache_key(ar)
-
-If the passed in object is not an AnalysisRequest, this function raises `DontCache`::
-
-    >>> api.get_ar_cache_key(client)
-    Traceback (most recent call last):
-    ...
-    DontCache
-
-
 Bika Cache Key decorator
 ------------------------
 

--- a/bika/lims/docs/API.rst
+++ b/bika/lims/docs/API.rst
@@ -1028,7 +1028,7 @@ the second argument a brain or object::
     >>> class BikaClass(object):
     ...     @cache(api.bika_cache_key_decorator)
     ...     def get_very_expensive_calculation(self, obj):
-    ...         print "get_id was called"
+    ...         print "very expensive calculation"
     ...         return api.get_id(obj)
 
     >>> instance = BikaClass()
@@ -1036,7 +1036,7 @@ the second argument a brain or object::
 Calling the (expensive) method of the class does the calculation just once::
 
     >>> instance.get_very_expensive_calculation(client)
-    get_id was called
+    very expensive calculation
     'client-1'
 
     >>> instance.get_very_expensive_calculation(client)
@@ -1045,7 +1045,7 @@ Calling the (expensive) method of the class does the calculation just once::
 The decorator can also handle brains::
 
     >>> instance.get_very_expensive_calculation(brain)
-    get_id was called
+    very expensive calculation
     'client-1'
 
     >>> instance.get_very_expensive_calculation(brain)

--- a/bika/lims/docs/API.rst
+++ b/bika/lims/docs/API.rst
@@ -676,6 +676,31 @@ Reactivate the client::
     'active'
 
 
+Getting the available transitions for an object
+-----------------------------------------------
+
+This function returns all possible transitions from all workflows in the
+object's workflow chain.
+
+Let's create a Batch. It should allow us to invoke transitions from two
+workflows; 'close' from the bika_batch_workflow, and 'cancel' from the
+bika_cancellation_workflow::
+
+    >>> batch1 = api.create(portal.batches, "Batch", title="Test Batch")
+    >>> transitions = api.get_transitions_for(batch1)
+    >>> len(transitions)
+    2
+
+The transitions are returned as a list of dictionaries. Since we cannot rely on
+the order of dictionary keys, we will have to satisfy ourselves here with
+checking that the two expected transitions are present in the return value::
+
+    >>> 'Close' in [t['title'] for t in transitions]
+    True
+    >>> 'Cancel' in [t['title'] for t in transitions]
+    True
+
+
 Getting the creation date of an object
 --------------------------------------
 

--- a/bika/lims/subscribers/configure.zcml
+++ b/bika/lims/subscribers/configure.zcml
@@ -11,12 +11,13 @@
       handler="bika.lims.subscribers.after_transition_log.AfterTransitionEventHandler"
       />
 
-  <!-- Transition event handler -->
+  <!-- BikaBeforeTransitionEvent handler -->
   <subscriber
       for="*
-           Products.DCWorkflow.interfaces.IAfterTransitionEvent"
-      handler="bika.lims.subscribers.on_transition.after_transition_handler"
+           bika.lims.api.IBikaBeforeTransitionEvent"
+      handler="bika.lims.subscribers.on_transition.before_transition_handler"
       />
+
 
   <!-- Newly created analyses -->
   <subscriber

--- a/bika/lims/subscribers/configure.zcml
+++ b/bika/lims/subscribers/configure.zcml
@@ -11,6 +11,13 @@
       handler="bika.lims.subscribers.after_transition_log.AfterTransitionEventHandler"
       />
 
+  <!-- Transition event handler -->
+  <subscriber
+      for="*
+           Products.DCWorkflow.interfaces.IAfterTransitionEvent"
+      handler="bika.lims.subscribers.on_transition.after_transition_handler"
+      />
+
   <!-- Newly created analyses -->
   <subscriber
       for="*

--- a/bika/lims/subscribers/on_transition.py
+++ b/bika/lims/subscribers/on_transition.py
@@ -1,0 +1,10 @@
+import DateTime
+
+def after_transition_handler(instance, event):
+
+    # creation doesn't have a 'transition'
+    if event.transition is None:
+        return
+
+    now = DateTime.DateTime()
+    instance.setModificationDate(now)

--- a/bika/lims/subscribers/on_transition.py
+++ b/bika/lims/subscribers/on_transition.py
@@ -6,8 +6,39 @@
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
 import DateTime
+from bika.lims import api
 
 
 def before_transition_handler(instance, event):
-    now = DateTime.DateTime()
-    instance.setModificationDate(now)
+    parent = api.get_parent(instance)
+    if api.get_portal_type(instance) == "AnalysisRequest":
+        update_ar_modification_dates(instance)
+    elif api.get_portal_type(parent) == "AnalysisRequest":
+        update_ar_modification_dates(parent)
+    else:
+        update_modification_date(instance)
+
+
+def update_ar_modification_dates(ar):
+    # update the sample modification date
+    sample = ar.getSample()
+    update_modification_date(sample)
+
+    # update partitions modification date
+    for part in ar.getPartitions():
+        update_modification_date(part)
+
+    # update attachments modification date
+    for att in ar.getAttachment():
+        update_modification_date(att)
+
+    # update analyses modification date
+    for an in ar.getAnalyses():
+        update_modification_date(an)
+
+
+def update_modification_date(obj):
+    """update the modification date of the object"""
+    if obj is None:
+        return
+    obj.setModificationDate(DateTime.DateTime())

--- a/bika/lims/subscribers/on_transition.py
+++ b/bika/lims/subscribers/on_transition.py
@@ -1,3 +1,10 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of Bika LIMS
+#
+# Copyright 2011-2017 by it's authors.
+# Some rights reserved. See LICENSE.txt, AUTHORS.txt.
+
 import DateTime
 
 def after_transition_handler(instance, event):

--- a/bika/lims/subscribers/on_transition.py
+++ b/bika/lims/subscribers/on_transition.py
@@ -10,6 +10,10 @@ from bika.lims import api
 
 
 def before_transition_handler(instance, event):
+    """Always update the modification date before a WF transition.
+
+    This ensures that all cache keys are invalidated.
+    """
     parent = api.get_parent(instance)
     if api.get_portal_type(instance) == "AnalysisRequest":
         update_ar_modification_dates(instance)
@@ -20,6 +24,13 @@ def before_transition_handler(instance, event):
 
 
 def update_ar_modification_dates(ar):
+    """Update the modification date of the AR and all contained elemensof the AR and all contained elements.
+
+    This is necessary to be able to cache the AR with a simple cache key that checks the modification date.
+    """
+    # update the modification date of the ar itself
+    update_modification_date(ar)
+
     # update the sample modification date
     sample = ar.getSample()
     update_modification_date(sample)
@@ -38,7 +49,9 @@ def update_ar_modification_dates(ar):
 
 
 def update_modification_date(obj):
-    """update the modification date of the object"""
+    """Set the modification date of the object to the current time
+    """
+    # we don't want to fail in here
     if obj is None:
         return
     obj.setModificationDate(DateTime.DateTime())

--- a/bika/lims/subscribers/on_transition.py
+++ b/bika/lims/subscribers/on_transition.py
@@ -7,11 +7,7 @@
 
 import DateTime
 
-def after_transition_handler(instance, event):
 
-    # creation doesn't have a 'transition'
-    if event.transition is None:
-        return
-
+def before_transition_handler(instance, event):
     now = DateTime.DateTime()
     instance.setModificationDate(now)

--- a/bika/lims/workflow.py
+++ b/bika/lims/workflow.py
@@ -57,10 +57,9 @@ def doActionFor(instance, action_id):
         try:
             api.do_transition_for(instance, action_id)
             actionperformed = True
-        except ploneapi.exc.InvalidParameterError as e:
+        except api.BikaLIMSError as e:
             message = str(e)
-            logger.warn("Failed to perform transition {} on {}: {}".format(
-                action_id, instance, message))
+            logger.warn(message)
     return actionperformed, message
 
 

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.4.0 (unreleased)
 ------------------
 
+- Issue-2198: Bika listing cache key does not invalidate after WF transitions
 - Issue-2183: Don't recalculate prices when option "Include and display pricing information" in Bika Setup Accounting is not selected
 - Sampler and Sampling Date Columns are not validated when they are not displayed
 - Issue-2162: Added renameAfterCreation to partition creation in ARImport


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Part of Issue https://github.com/bikalims/bika.lims/issues/2178

## Current behavior before PR

The Bika listing `cache_key` did only calculate the `UID` and the `modified` values. Unfortunately a WF transition leave the modification date unchanged.

From Slack:
<hr/>
mikemets [16:01] 
Recently we introduced some caching on the bika_listing and today it bit us in the butt. The cache key contained the method, uid and modified date. Unfortunately plone doesn't seem to update the modified date after transitioning on object's workflow. So we added the state to the key.  This works but looking up the state is not quick so I thought of adding an AfterTransition subscriber that does update modified. Anyone got any other ideas?
<hr/>

## Desired behavior after PR is merged

The brain is passed into the `cache_key` function to calculate the `review_state` as well.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
