### PR TITLE
Added AR number selector to AR Add form

### DIFF
--- a/bika/lims/browser/analysisrequest/templates/ar_add2.pt
+++ b/bika/lims/browser/analysisrequest/templates/ar_add2.pt
@@ -324,8 +324,8 @@
                   <span i18n:translate="">Manage Form Fields</span>
                 </a>
               </div>
-            </td><td>
             </td>
+            <td></td>
             <tal:columns tal:repeat="arnum python:range(view.ar_count)">
               <td class="ar-column-header">
                 <span i18n:translate="">Sample</span>

--- a/bika/lims/browser/analysisrequest/templates/ar_add2.pt
+++ b/bika/lims/browser/analysisrequest/templates/ar_add2.pt
@@ -274,18 +274,19 @@
       <h1 id="ar-header">
         <img tal:condition="view/icon | nothing" tal:attributes="src view/icon"/>
         <span i18n:translate="">Request new analyses</span>
+        <form style="display:inline-block;" method="POST">
+          <input type="number"
+                 name="ar_count"
+                 min="1"
+                 class="context_action_link"
+                 style="width:4em;border-radius:0;border:1px solid #ddd;padding:2px;"
+                 tal:attributes="value view/ar_count"/>
+          <button type="submit"
+                  class="btn btn-link context_action_link">
+            <img tal:attributes="src string:${view/portal_url}/++resource++bika.lims.images/add.png" />
+          </button>
+        </form>
       </h1>
-      <div id="manage-ar-fields"
-           tal:condition="python:user.has_role('LabManager') or user.has_role('Manager')">
-        <a id="manage-ar-fields-link"
-           href=""
-           class="btn btn-link"
-           target="_blank"
-           i18n:translate=""
-           tal:attributes="href python:context.absolute_url() + '/ar_add_manage'">
-          (&#9998; Manage Fields)
-        </a>
-      </div>
     </metal:title>
     <metal:description fill-slot="content-description">
     </metal:description>
@@ -311,8 +312,20 @@
         <table class="ar-table grid">
 
           <tr>
-            <td></td>
-            <td></td>
+            <td>
+              <div id="manage-ar-fields"
+                  tal:condition="python:user.has_role('LabManager') or user.has_role('Manager')">
+                <a id="manage-ar-fields-link"
+                  href=""
+                  class="btn btn-link"
+                  target="_blank"
+                  tal:attributes="href python:context.absolute_url() + '/ar_add_manage'">
+                  &#9998;
+                  <span i18n:translate="">Manage Form Fields</span>
+                </a>
+              </div>
+            </td><td>
+            </td>
             <tal:columns tal:repeat="arnum python:range(view.ar_count)">
               <td class="ar-column-header">
                 <span i18n:translate="">Sample</span>


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Minor UI change to allow to change the AR number in the AR Add form.

Note: it is done very simple with a complete page reload, but this would also happen if one navigates back.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
