### PR TITLE
Issue-2211: Added controls to change the number of ARs in the AR Add form

### DIFF
--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -107,6 +107,16 @@ class AnalysisRequestAddView(BrowserView):
         logger.info("*** Prepared data for {} ARs ***".format(self.ar_count))
         return self.template()
 
+    def get_view_url(self):
+        """Return the current view url including request parameters
+        """
+        request = self.request
+        url = request.getURL()
+        qs = request.getHeader("query_string")
+        if not qs:
+            return url
+        return "{}?{}".format(url, qs)
+
     def get_object_by_uid(self, uid):
         """Get the object by UID
         """

--- a/bika/lims/browser/analysisrequest/templates/ar_add2.pt
+++ b/bika/lims/browser/analysisrequest/templates/ar_add2.pt
@@ -274,18 +274,20 @@
       <h1 id="ar-header">
         <img tal:condition="view/icon | nothing" tal:attributes="src view/icon"/>
         <span i18n:translate="">Request new analyses</span>
-        <form style="display:inline-block;" method="POST">
+        <span id="ar-count-control" class="form-inline">
           <input type="number"
                  name="ar_count"
                  min="1"
-                 class="context_action_link"
-                 style="width:4em;border-radius:0;border:1px solid #ddd;padding:2px;"
+                 class="form-control"
+                 style="width:4em"
                  tal:attributes="value view/ar_count"/>
-          <button type="submit"
-                  class="btn btn-link context_action_link">
-            <img tal:attributes="src string:${view/portal_url}/++resource++bika.lims.images/add.png" />
-          </button>
-        </form>
+          <a href=""
+             id="ar_count_change"
+             tal:attributes="href string:${view/get_view_url}"
+             class="btn btn-default btn-sm">
+            <span i18n:translate="">Reload Form</span>
+          </a>
+        </span>
       </h1>
     </metal:title>
     <metal:description fill-slot="content-description">

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -16,6 +16,7 @@
       this.on_ajax_start = bind(this.on_ajax_start, this);
       this.ajax_post_form = bind(this.ajax_post_form, this);
       this.on_copy_button_click = bind(this.on_copy_button_click, this);
+      this.on_ar_count_change = bind(this.on_ar_count_change, this);
       this.on_service_category_click = bind(this.on_service_category_click, this);
       this.on_service_listing_header_click = bind(this.on_service_listing_header_click, this);
       this.on_reportdrymatter_click = bind(this.on_reportdrymatter_click, this);
@@ -98,6 +99,7 @@
       $("tr[fieldname=Profiles] input[type='text']").on("selected", this.on_analysis_profile_selected);
       $("tr[fieldname=Profiles] img.deletebtn").live("click", this.on_analysis_profile_removed);
       $("img.copybutton").on("click", this.on_copy_button_click);
+      $("#ar-count-control input[name=ar_count]").on("change", this.on_ar_count_change);
 
       /* internal events */
       $(this).on("form:changed", this.recalculate_records);
@@ -1085,6 +1087,24 @@
         services.addClass("visible");
         return services.addClass("expanded");
       }
+    };
+
+    AnalysisRequestAdd.prototype.on_ar_count_change = function(event) {
+
+      /*
+       * Eventhandler for ar_count number field
+       */
+      var $el, ar_count, el, href, link, new_href;
+      el = event.target;
+      $el = $(el);
+      ar_count = $el.val();
+      href = location.href;
+      if (href.search("ar_count") < 0) {
+        href += href.split('?')[1] ? '&ar_count=1' : '?ar_count=1';
+      }
+      new_href = href.replace(/ar_count=[0-9]+/, "ar_count=" + ar_count);
+      link = $("#ar_count_change", $el.parent());
+      return link.attr("href", new_href);
     };
 
     AnalysisRequestAdd.prototype.on_copy_button_click = function(event) {

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -85,6 +85,8 @@ class window.AnalysisRequestAdd
     $("tr[fieldname=Profiles] img.deletebtn").live "click", @on_analysis_profile_removed
     # Copy button clicked
     $("img.copybutton").on "click", @on_copy_button_click
+    # AR Controls
+    $("#ar-count-control input[name=ar_count]").on "change", @on_ar_count_change
 
     ### internal events ###
 
@@ -1210,6 +1212,23 @@ class window.AnalysisRequestAdd
       $el.addClass "expanded"
       services.addClass "visible"
       services.addClass "expanded"
+
+
+  on_ar_count_change: (event) =>
+    ###
+     * Eventhandler for ar_count number field
+    ###
+    el = event.target
+    $el = $(el)
+    ar_count = $el.val()
+    href = location.href
+    # append ar_count to the url if it is missing
+    if href.search("ar_count") < 0
+      href += if href.split('?')[1] then '&ar_count=1' else '?ar_count=1'
+    new_href = href.replace(/ar_count=[0-9]+/, "ar_count=#{ar_count}")
+    link = $("#ar_count_change", $el.parent())
+    # set the new link
+    link.attr("href", new_href)
 
 
   on_copy_button_click: (event) =>

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.2.1rc1 (unreleased)
 ---------------------
 
+- Issue-2211: Allow to change the Number of ARs in the AR Add form
 - Issue-2207: Invalid jQuery selector in Referencewidget
 - Issue-2200: Bika Listing Cachekey ignores different virtual host configurations
 - Issue-2198: Bika listing cache key does not invalidate after WF transitions


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Please see https://github.com/bikalims/bika.lims/issues/2211 for details.

## Current behavior before PR

It is not possible to change the number of ARs in AR Add form

## Desired behavior after PR is merged

AR controls added to change the number of ARs in AR Add form

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
