### PR TITLE
Add an extra param "portal_type=None" to generateUniqueId

### DIFF
--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -54,10 +54,12 @@ def idserver_generate_id(context, prefix, batch_size=None):
     return new_id
 
 
-def generateUniqueId(context, parent=False):
+def generateUniqueId(context, parent=False, portal_type=''):
     """ Generate pretty content IDs.
     """
 
+    if portal_type == '':
+        portal_type = context.portal_type
     def getLastCounter(context, config):
         if config.get('counter_type', '') == 'backreference':
             return len(context.getBackReferences(config['counter_reference'])) - 1
@@ -83,18 +85,18 @@ def generateUniqueId(context, parent=False):
     config_map = api.get_bika_setup().getIDFormatting()
     config = getConfigByPortalType(
         config_map=config_map,
-        portal_type=context.portal_type)
-    if context.portal_type == "AnalysisRequest":
+        portal_type=portal_type)
+    if portal_type == "AnalysisRequest":
         variables_map = {
             'sampleId': context.getSample().getId(),
             'sample': context.getSample(),
         }
-    elif context.portal_type == "SamplePartition":
+    elif portal_type == "SamplePartition":
         variables_map = {
             'sampleId': context.aq_parent.getId(),
             'sample': context.aq_parent,
         }
-    elif context.portal_type == "Sample" and parent:
+    elif portal_type == "Sample" and parent:
         config = getConfigByPortalType(
             config_map=config_map,
             portal_type='SamplePartition')  # Override
@@ -102,7 +104,7 @@ def generateUniqueId(context, parent=False):
             'sampleId': context.getId(),
             'sample': context,
         }
-    elif context.portal_type == "Sample":
+    elif portal_type == "Sample":
         sampleDate = None
         if context.getSamplingDate():
             sampleDate = DT2dt(context.getSamplingDate())
@@ -117,9 +119,9 @@ def generateUniqueId(context, parent=False):
         if not config:
             # Provide default if no format specified on bika_setup
             config = {
-                'form': '%s-{seq}' % context.portal_type.lower(),
+                'form': '%s-{seq}' % portal_type.lower(),
                 'sequence_type': 'generated',
-                'prefix': '%s' % context.portal_type.lower(),
+                'prefix': '%s' % portal_type.lower(),
             }
         variables_map = {}
 

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.4.0 (unreleased)
 ------------------
 
+- Added argument portal_type on the function generateUniqueId so that it's not used for objects only
 - Issue-2183: Don't recalculate prices when option "Include and display pricing information" in Bika Setup Accounting is not selected
 - Sampler and Sampling Date Columns are not validated when they are not displayed
 - Issue-2162: Added renameAfterCreation to partition creation in ARImport

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,7 +1,7 @@
 3.4.0 (unreleased)
 ------------------
 
-- Added argument portal_type on the function generateUniqueId so that it's not used for objects only
+- 2215: Added extra param portal_type on the function generateUniqueId so that it's not used for objects only
 - Issue-2183: Don't recalculate prices when option "Include and display pricing information" in Bika Setup Accounting is not selected
 - Sampler and Sampling Date Columns are not validated when they are not displayed
 - Issue-2162: Added renameAfterCreation to partition creation in ARImport


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://github.com/bikalabs/bika.lims/issues/2215


## Current behavior before PR
     IDServer generates ids for content types objects only 

## Desired behavior after PR is merged
     This allows us to gen ids for none content type objects like reports that aren't saved.
--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
