### PR TITLE
Issue-2218: Update modification dates when setting a proxy field

### DIFF
--- a/bika/lims/browser/fields/proxyfield.py
+++ b/bika/lims/browser/fields/proxyfield.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 
+import DateTime
+
 from zope.interface import implements
 
 from AccessControl import ClassSecurityInfo
@@ -96,6 +98,15 @@ class ProxyField(ObjectField):
 
         # set the value on the proxy object
         field.set(proxy_object, value, **kwargs)
+
+        # get the current time
+        now = DateTime.DateTime()
+
+        # update the modification date of the proxied object
+        proxy_object.setModificationDate(now)
+
+        # update the modification date of the holding object
+        instance.setModificationDate(now)
 
 
 # Register the field

--- a/bika/lims/docs/AnalysisRequests.rst
+++ b/bika/lims/docs/AnalysisRequests.rst
@@ -122,6 +122,26 @@ of the underlying Sample (https://github.com/bikalabs/bika.lims/issues/1992)::
     >>> sample
     <Sample at /plone/clients/client-1/water-0001>
 
+Since Proxy Fields modify *only* the proxied object, the holding object's modification date
+needs to be updated as well (https://github.com/bikalims/bika.lims/issues/2218)::
+
+    >>> ar_mdate = api.get_modification_date(ar)
+    >>> sample_mdate = api.get_modification_date(sample)
+
+Now we update a proxied field value::
+
+    >>> ar.setClientReference(4711)
+
+The modification date of the AR should be updated::
+
+    >>> api.get_modification_date(ar) != ar_mdate
+    True
+
+And the modification date of the Sample should be upated::
+
+    >>> api.get_modification_date(sample) != sample_mdate
+    True
+
 
 DateSampled
 ...........

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.3.0 (unreleased)
 ------------------
 
+- Issue-2218: Cache Key does not invalidate if proxied Sample values of ARs change
 - Issue-2204: Notification Emails on AR retract
 - Issue-2173: Publishing multiple ARs fails
 - Issue-2132: Reorderable Attachments for Reports


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Please see https://github.com/bikalabs/bika.lims/issues/2218 for details.

## Current behavior before PR

Modification dates were not updated when a value was set on a proxy field

## Desired behavior after PR is merged

Modification date is set on proxy and holder object.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
