### PR TITLE
LIMS-2695: Improve performance of worksheet results view

### DIFF
--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -2,6 +2,8 @@
 ------------------
 
 - 2215: Added extra param portal_type on the function generateUniqueId so that it's not used for objects only
+- LIMS-2695: Improve performance of worksheet results (manage_analyses) view
+- Saving '-----' and negetive values as 0(Only for Shimadzu instruments)
 - Issue-2183: Don't recalculate prices when option "Include and display pricing information" in Bika Setup Accounting is not selected
 - Sampler and Sampling Date Columns are not validated when they are not displayed
 - Issue-2162: Added renameAfterCreation to partition creation in ARImport


### PR DESCRIPTION
(cherry picked from commit 7fa47a7e99bbcf1512319b37815cb18591f2dfc2)

Cache some expensive function calls, including historyawarereferencefield/get.

## Description of the issue/feature this PR addresses

https://jira.bikalabs.com/browse/LIMS-2695

## Current behavior before PR

Worksheet manage_results view is very slow

## Desired behavior after PR is merged

performance is acceptable

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
