### PR TITLE
Issue-2230: ID Server: Normalize Sample Type

### DIFF
--- a/bika/lims/api.py
+++ b/bika/lims/api.py
@@ -1070,7 +1070,6 @@ def normalize_id(string):
     :returns: Normalized ID
     :rtype: str
     """
-
     if not isinstance(string, basestring):
         fail("Type of argument must be string, found '{}'".format(type(string)))
     # get the id nomalizer utility

--- a/bika/lims/api.py
+++ b/bika/lims/api.py
@@ -32,6 +32,8 @@ from plone import api as ploneapi
 from plone.api.exc import InvalidParameterError
 from plone.dexterity.interfaces import IDexterityContent
 from plone.app.layout.viewlets.content import ContentHistoryView
+from plone.i18n.normalizer.interfaces import IFileNameNormalizer
+from plone.i18n.normalizer.interfaces import IIDNormalizer
 
 from bika.lims import logger
 
@@ -1058,3 +1060,34 @@ def bika_cache_key_decorator(method, self, brain_or_object):
     :rtype: str
     """
     return get_cache_key(brain_or_object)
+
+
+def normalize_id(string):
+    """Normalize the id
+
+    :param string: A string to normalize
+    :type string: str
+    :returns: Normalized ID
+    :rtype: str
+    """
+
+    if not isinstance(string, basestring):
+        fail("Type of argument must be string, found '{}'".format(type(string)))
+    # get the id nomalizer utility
+    normalizer = getUtility(IIDNormalizer).normalize
+    return normalizer(string)
+
+
+def normalize_filename(string):
+    """Normalize the filename
+
+    :param string: A string to normalize
+    :type string: str
+    :returns: Normalized ID
+    :rtype: str
+    """
+    if not isinstance(string, basestring):
+        fail("Type of argument must be string, found '{}'".format(type(string)))
+    # get the file nomalizer utility
+    normalizer = getUtility(IFileNameNormalizer).normalize
+    return normalizer(string)

--- a/bika/lims/docs/API.rst
+++ b/bika/lims/docs/API.rst
@@ -1034,3 +1034,37 @@ The decorator can also handle brains::
 
     >>> instance.get_very_expensive_calculation(brain)
     'client-1'
+
+
+ID Normalizer
+-------------
+
+Normalizes a string to be usable as a system ID:
+
+    >>> api.normalize_id("My new ID")
+    'my-new-id'
+
+    >>> api.normalize_id("Really/Weird:Name;")
+    'really-weird-name'
+
+    >>> api.normalize_id(None)
+    Traceback (most recent call last):
+    [...]
+    BikaLIMSError: Type of argument must be string, found '<type 'NoneType'>'
+
+
+File Normalizer
+---------------
+
+Normalizes a string to be usable as a file name:
+
+    >>> api.normalize_filename("My new ID")
+    'My new ID'
+
+    >>> api.normalize_filename("Really/Weird:Name;")
+    'Really-Weird-Name'
+
+    >>> api.normalize_filename(None)
+    Traceback (most recent call last):
+    [...]
+    BikaLIMSError: Type of argument must be string, found '<type 'NoneType'>'

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -106,13 +106,14 @@ def generateUniqueId(context, parent=False, portal_type=''):
         }
     elif portal_type == "Sample":
         sampleDate = None
+        sampleType = context.getSampleType().getPrefix()
         if context.getSamplingDate():
             sampleDate = DT2dt(context.getSamplingDate())
 
         variables_map = {
             'clientId': context.aq_parent.getClientID(),
             'sampleDate': sampleDate,
-            'sampleType': context.getSampleType().getPrefix(),
+            'sampleType': api.normalize_filename(sampleType),
             'year': DateTime().strftime("%Y")[2:],
         }
     else:

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.4.0 (unreleased)
 ------------------
 
+- Issue-2230: IDServer fails to rename Samples with a non-id-compliant SampleType
 - 2215: Added extra param portal_type on the function generateUniqueId so that it's not used for objects only
 - Issue-2183: Don't recalculate prices when option "Include and display pricing information" in Bika Setup Accounting is not selected
 - Sampler and Sampling Date Columns are not validated when they are not displayed


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Please see https://github.com/bikalims/bika.lims/issues/2230 for further details.

## Current behavior before PR

AR creation fails if the Sample Type contains characters which are illegal in IDs

## Desired behavior after PR is merged

AR creation works even for Sample Types with weird names

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
