### PR TITLE
Issue-2218: Use the object to create the cached listing item

### DIFF
--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -849,12 +849,12 @@ class BikaListingView(BrowserView):
         return fti.Title()
 
     @cache(api.bika_cache_key_decorator, store_on_context)
-    def make_listing_item(self, brain):
+    def make_listing_item(self, obj):
         """Returns an object dictionary suitable for the listing view
         """
 
         # ensure we have an object
-        obj = api.get_object(brain)
+        obj = api.get_object(obj)
 
         # prepare some data
         id = api.get_id(obj)
@@ -1045,7 +1045,7 @@ class BikaListingView(BrowserView):
                 continue
 
             # create a listing item
-            results_dict = self.make_listing_item(brain)
+            results_dict = self.make_listing_item(obj)
 
             # Search for values for all columns in obj
             for key in self.columns.keys():


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This is the second PR to fix https://github.com/bikalims/bika.lims/issues/2218.

## Current behavior before PR

AR listing table does not update its view when an AR was updated

## Desired behavior after PR is merged

Row in AR listing updates the value.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
