### PR TITLE
BC-147 On the WS Add Analyses View, sort by due date

### DIFF
--- a/bika/lims/browser/worksheet/views/add_analyses.py
+++ b/bika/lims/browser/worksheet/views/add_analyses.py
@@ -39,7 +39,8 @@ class AddAnalysesView(BikaListingView):
         self.contentFilter = {'portal_type': 'Analysis',
                               'review_state':'sample_received',
                               'worksheetanalysis_review_state':'unassigned',
-                              'cancellation_state':'active'}
+                              'cancellation_state':'active',
+                              'sort_on': 'getDueDate'}
         self.base_url = self.context.absolute_url()
         self.view_url = self.base_url + "/add_analyses"
         self.show_sort_column = False

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.4.0 (unreleased)
 ------------------
 
+- BC-147: Default empty WS view should list on due date
 - Issue-2103: WS Templates not offered for selection
 - Instrument selection for creating WSs does not work
 - Issue-2215: Added extra param portal_type on the function generateUniqueId so that it's not used for objects only


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://jira.bikalabs.com/browse/BC-147


## Current behavior before PR
      On the WS Add Analyses view default sort is by Client
## Desired behavior after PR is merged
     On the WS Add Analyses view default sort should be by Due Date
--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
