### PR TITLE
Changed default Report Option in Attachment viewlet to Render In Report

### DIFF
--- a/bika/lims/config.py
+++ b/bika/lims/config.py
@@ -60,9 +60,9 @@ ATTACHMENT_OPTIONS = DisplayList((
     ('n', _('Not Permitted')),
 ))
 ATTACHMENT_REPORT_OPTIONS = DisplayList((
+    ('r', _('Render in Report')),
     ('a', _('Attach to Report')),
     ('i', _('Ignore in Report')),
-    ('r', _('Render in Report')),
 ))
 DEFAULT_AR_SPECS = DisplayList((
     ('ar_specs', _('Analysis Request Specifications')),


### PR DESCRIPTION
## Description of the issue/feature this PR addresses


https://github.com/bikalabs/bika.lims/issues/2239

## Current behavior before PR
Default is Attached to Report

## Desired behavior after PR is merged
Default to Render in Report
--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
