### PR TITLE
Issue-2242: New AR Add Form: Local Samplepoints with the same Sampletype from other clients get displayed

### DIFF
--- a/bika/lims/api.py
+++ b/bika/lims/api.py
@@ -29,6 +29,7 @@ from zope.lifecycleevent import ObjectCreatedEvent
 from zope.security.interfaces import Unauthorized
 
 from plone import api as ploneapi
+from plone.memoize.volatile import DontCache
 from plone.api.exc import InvalidParameterError
 from plone.dexterity.interfaces import IDexterityContent
 from plone.app.layout.viewlets.content import ContentHistoryView
@@ -1057,4 +1058,6 @@ def bika_cache_key_decorator(method, self, brain_or_object):
     :returns: Cache Key
     :rtype: str
     """
+    if brain_or_object is None:
+        raise DontCache
     return get_cache_key(brain_or_object)

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1063,6 +1063,21 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         """
         info = self.get_base_info(obj)
 
+        # Bika Setup folder
+        bika_setup = api.get_bika_setup()
+
+        # bika samplepoints
+        bika_samplepoints = bika_setup.bika_samplepoints
+        bika_samplepoints_uid = api.get_uid(bika_samplepoints)
+
+        # bika analysisspecs
+        bika_analysisspecs = bika_setup.bika_analysisspecs
+        bika_analysisspecs_uid = api.get_uid(bika_analysisspecs)
+
+        # client
+        client = self.get_client()
+        client_uid = api.get_uid(client)
+
         # sample matrix
         sample_matrix = obj.getSampleMatrix()
         sample_matrix_uid = sample_matrix and sample_matrix.UID() or ""
@@ -1094,10 +1109,12 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         # catalog queries for UI field filtering
         filter_queries = {
             "samplepoint": {
-                "getSampleTypeTitle": obj.Title()
+                "getSampleTypeTitle": obj.Title(),
+                "getClientUID": [client_uid, bika_samplepoints_uid],
             },
             "specification": {
-                "getSampleTypeTitle": obj.Title()
+                "getSampleTypeTitle": obj.Title(),
+                "getClientUID": [client_uid, bika_analysisspecs_uid],
             }
         }
         info["filter_queries"] = filter_queries

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -14,9 +14,9 @@ from BTrees.OOBTree import OOBTree
 
 from plone import protect
 from plone.memoize import view
+
 from plone.memoize.volatile import cache
 from plone.memoize.volatile import DontCache
-from plone.memoize.volatile import store_on_context
 
 from zope.annotation.interfaces import IAnnotations
 from zope.publisher.interfaces import IPublishTraverse
@@ -50,18 +50,10 @@ def returns_json(func):
     return decorator
 
 
-def gen_key(brain_or_object):
-    obj = api.get_object(brain_or_object)
-    uid = api.get_uid(obj)
-    modified = obj.modified().ISO8601()
-    portal_type = api.get_portal_type(obj)
-    return "{}-{}-{}".format(portal_type, uid, modified)
-
-
 def cache_key(method, self, obj):
     if obj is None:
         raise DontCache
-    return gen_key(obj)
+    return api.get_cache_key(obj)
 
 
 def mg(value):
@@ -512,7 +504,7 @@ class AnalysisRequestAddView(BrowserView):
             analyses[category].append(brain)
         return analyses
 
-    @cache(cache_key, store_on_context)
+    @cache(cache_key)
     def get_service_uid_from(self, analysis):
         """Return the service from the analysis
         """
@@ -890,7 +882,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         objs = map(self.get_object_by_uid, uids)
         return dict(zip(uids, objs))
 
-    @cache(cache_key, store_on_context)
+    @cache(cache_key)
     def get_base_info(self, obj):
         """Returns the base info of an object
         """
@@ -907,7 +899,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
         return info
 
-    @cache(cache_key, store_on_context)
+    @cache(cache_key)
     def get_client_info(self, obj):
         """Returns the client info of an object
         """
@@ -967,7 +959,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
         return info
 
-    @cache(cache_key, store_on_context)
+    @cache(cache_key)
     def get_service_info(self, obj):
         """Returns the info for a Service
         """
@@ -995,7 +987,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         # info["dependendants"] = map(self.get_base_info, dependants)
         return info
 
-    @cache(cache_key, store_on_context)
+    @cache(cache_key)
     def get_template_info(self, obj):
         """Returns the info for a Template
         """
@@ -1041,7 +1033,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         })
         return info
 
-    @cache(cache_key, store_on_context)
+    @cache(cache_key)
     def get_profile_info(self, obj):
         """Returns the info for a Profile
         """
@@ -1049,7 +1041,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         info.update({})
         return info
 
-    @cache(cache_key, store_on_context)
+    @cache(cache_key)
     def get_method_info(self, obj):
         """Returns the info for a Method
         """
@@ -1057,7 +1049,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         info.update({})
         return info
 
-    @cache(cache_key, store_on_context)
+    @cache(cache_key)
     def get_calculation_info(self, obj):
         """Returns the info for a Calculation
         """
@@ -1065,7 +1057,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         info.update({})
         return info
 
-    @cache(cache_key, store_on_context)
+    @cache(cache_key)
     def get_sampletype_info(self, obj):
         """Returns the info for a Sample Type
         """
@@ -1112,7 +1104,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
         return info
 
-    @cache(cache_key, store_on_context)
+    @cache(cache_key)
     def get_sample_info(self, obj):
         """Returns the info for a Sample
         """
@@ -1167,7 +1159,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         })
         return info
 
-    @cache(cache_key, store_on_context)
+    @cache(cache_key)
     def get_specification_info(self, obj):
         """Returns the info for a Specification
         """
@@ -1207,7 +1199,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         info["service_uids"] = specifications.keys()
         return info
 
-    @cache(cache_key, store_on_context)
+    @cache(cache_key)
     def get_container_info(self, obj):
         """Returns the info for a Container
         """
@@ -1215,7 +1207,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
         info.update({})
         return info
 
-    @cache(cache_key, store_on_context)
+    @cache(cache_key)
     def get_preservation_info(self, obj):
         """Returns the info for a Preservation
         """

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -127,5 +127,5 @@ scripts = ipython=ipzope
 
 [versions]
 setuptools =
-zc.buildout = 2.9.4
+zc.buildout =
 CairoSVG = 1.0.20

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,7 +1,7 @@
 3.2.1rc3 (unreleased)
 ---------------------
 
-- no changes yet
+- Issue-2242: New AR Add Form: Local Samplepoints with the same Sampletype from other clients get displayed
 
 
 3.2.1rc2 (2017-09-15)

--- a/travis.cfg
+++ b/travis.cfg
@@ -16,8 +16,8 @@ allow-hosts =
     dist.plone.org
 
 [versions]
-Plone=4.3.15
-zc.buildout = 2.9.4
+Plone = 4.3.15
+zc.buildout =
 setuptools =
 CairoSVG = 1.0.20
 Sphinx = 1.1.3


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://github.com/bikalims/bika.lims/issues/2242

## Current behavior before PR

Sample Points and Analysisspecs of all clients are displayed after the sample type was set in AR Add.

## Desired behavior after PR is merged

Only client-local Sample Points and Analysisspecs are displayed after the sample type was set in AR Add.

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
