### PR TITLE
Issue 2244: New AR Add Form: Local Samplepoints with the same Sampletype from other clients get displayed

### DIFF
--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -952,7 +952,10 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
                 "getClientUID": [uid, bika_analysisspecs_uid],
             },
             "samplinground": {
-                "getParentUID": [uid]
+                "getParentUID": [uid],
+            },
+            "sample": {
+                "getClientUID": [uid],
             },
         }
         info["filter_queries"] = filter_queries

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -455,6 +455,9 @@
       this.set_reference_field_query(field, query);
       field = $("#SamplingRound-" + arnum);
       query = client.filter_queries.samplinground;
+      this.set_reference_field_query(field, query);
+      field = $("#Sample-" + arnum);
+      query = client.filter_queries.sample;
       return this.set_reference_field_query(field, query);
     };
 

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -488,6 +488,11 @@ class window.AnalysisRequestAdd
     query = client.filter_queries.samplinground
     @set_reference_field_query field, query
 
+    # filter Sample
+    field = $("#Sample-#{arnum}")
+    query = client.filter_queries.sample
+    @set_reference_field_query field, query
+
 
   set_sample: (arnum, sample) =>
     ###

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.2.1rc3 (unreleased)
 ---------------------
 
+- Issue-2244: New AR Add Form: Sample field does not filter by Client
 - Issue-2242: New AR Add Form: Local Samplepoints with the same Sampletype from other clients get displayed
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://github.com/bikalims/bika.lims/issues/2244

## Current behavior before PR

Samples from all clients were displayed in the AR Add form

## Desired behavior after PR is merged

Only samples from the locals client is displayed in the selection

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
