### PR TITLE
Issue-2241: New AR Add Form: Server Error when the Sample Type contains German Umlauts (unicode characters)

### DIFF
--- a/bika/lims/adapters/referencewidgetvocabulary.py
+++ b/bika/lims/adapters/referencewidgetvocabulary.py
@@ -21,6 +21,11 @@ class DefaultReferenceWidgetVocabulary(object):
         self.context = context
         self.request = request
 
+    def to_utf8(self, s):
+        if not isinstance(s, basestring):
+            return s
+        return _c(s)
+
     def __call__(self, result=None, specification=None, **kwargs):
         searchTerm = _c(self.request.get('searchTerm', '')).lower()
         force_all = self.request.get('force_all', 'true')
@@ -32,9 +37,10 @@ class DefaultReferenceWidgetVocabulary(object):
         catalog = getToolByName(self.context, catalog_name)
         base_query = json.loads(_c(self.request['base_query']))
         search_query = json.loads(_c(self.request.get('search_query', "{}")))
+
         # first with all queries
-        contentFilter = dict((k, v) for k, v in base_query.items())
-        contentFilter.update(search_query)
+        contentFilter = dict((k, self.to_utf8(v)) for k, v in base_query.items())
+        contentFilter.update(dict((k, self.to_utf8(v)) for k, v in search_query.items()))
         try:
             brains = catalog(contentFilter)
         except:

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.2.1rc3 (unreleased)
 ---------------------
 
+- Issue-2241: New AR Add Form: Server Error when the Sample Type contains German Umlauts (unicode characters)
 - Issue-2244: New AR Add Form: Sample field does not filter by Client
 - Issue-2242: New AR Add Form: Local Samplepoints with the same Sampletype from other clients get displayed
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://github.com/bikalims/bika.lims/issues/2241

## Current behavior before PR

UnicodeDecodeError occurs when the search value contains unicode characters when coming from the reference widget (e.g. clicking on the Sample Point field when the Sample Type is "Öl") 

## Desired behavior after PR is merged

Reference Widget returns the search results w/o errors

--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
