### PR TITLE
Issue-2237 recalculate prices on demand

### DIFF
--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1281,6 +1281,15 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
         return partitions
 
+    def ajax_get_global_settings(self):
+        """Returns the global Bika settings
+        """
+        bika_setup = api.get_bika_setup()
+        settings = {
+            "show_prices": bika_setup.getShowPrices(),
+        }
+        return settings
+
     def ajax_get_service(self):
         """Returns the services information
         """

--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -49,6 +49,7 @@
       this.update_form = bind(this.update_form, this);
       this.recalculate_prices = bind(this.recalculate_prices, this);
       this.recalculate_records = bind(this.recalculate_records, this);
+      this.get_global_settings = bind(this.get_global_settings, this);
       this.render_template = bind(this.render_template, this);
       this.template_dialog = bind(this.template_dialog, this);
       this.bind_eventhandler = bind(this.bind_eventhandler, this);
@@ -60,11 +61,13 @@
       jarn.i18n.loadCatalog('bika');
       this._ = window.jarn.i18n.MessageFactory('bika');
       $('input[type=text]').prop('autocomplete', 'off');
+      this.global_settings = {};
       this.records_snapshot = {};
       this.applied_templates = {};
       $(".blurrable").removeClass("blurrable");
       this.bind_eventhandler();
       this.init_file_fields();
+      this.get_global_settings();
       return this.recalculate_records();
     };
 
@@ -154,6 +157,18 @@
       return content;
     };
 
+    AnalysisRequestAdd.prototype.get_global_settings = function() {
+
+      /*
+       * Submit all form values to the server to recalculate the records
+       */
+      return this.ajax_post_form("get_global_settings").done(function(settings) {
+        console.debug("Global Settings:", settings);
+        this.global_settings = settings;
+        return $(this).trigger("settings:updated", settings);
+      });
+    };
+
     AnalysisRequestAdd.prototype.recalculate_records = function() {
 
       /*
@@ -171,6 +186,10 @@
       /*
        * Submit all form values to the server to recalculate the prices of all columns
        */
+      if (this.global_settings.show_prices === false) {
+        console.debug("*** Skipping Price calculation ***");
+        return;
+      }
       return this.ajax_post_form("recalculate_prices").done(function(data) {
         var arnum, prices;
         console.debug("Recalculate Prices Data=", data);

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -15,6 +15,9 @@ class window.AnalysisRequestAdd
     # disable browser autocomplete
     $('input[type=text]').prop 'autocomplete', 'off'
 
+    # storage for global Bika settings
+    @global_settings = {}
+
     # services data snapshot from recalculate_records
     # returns a mapping of arnum -> services data
     @records_snapshot = {}
@@ -33,6 +36,9 @@ class window.AnalysisRequestAdd
     # - All uploaded files are extracted and added as attachments to the new created AR
     # - The file field itself (Plone) will stay empty therefore
     @init_file_fields()
+
+    # get the global settings on load
+    @get_global_settings()
 
     # recalculate records on load (needed for AR copies)
     @recalculate_records()
@@ -149,6 +155,18 @@ class window.AnalysisRequestAdd
     return content
 
 
+  get_global_settings: =>
+    ###
+     * Submit all form values to the server to recalculate the records
+    ###
+    @ajax_post_form("get_global_settings").done (settings) ->
+      console.debug "Global Settings:", settings
+      # remember the global settings
+      @global_settings = settings
+      # trigger event for whom it might concern
+      $(@).trigger "settings:updated", settings
+
+
   recalculate_records: =>
     ###
      * Submit all form values to the server to recalculate the records
@@ -165,6 +183,11 @@ class window.AnalysisRequestAdd
     ###
      * Submit all form values to the server to recalculate the prices of all columns
     ###
+
+    if @global_settings.show_prices is false
+      console.debug "*** Skipping Price calculation ***"
+      return
+
     @ajax_post_form("recalculate_prices").done (data) ->
       console.debug "Recalculate Prices Data=", data
       for own arnum, prices of data

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.2.1rc3 (unreleased)
 ---------------------
 
+- Issue-2237: New AR Add Form: Include and display pricing information
 - Issue-2241: New AR Add Form: Server Error when the Sample Type contains German Umlauts (unicode characters)
 - Issue-2244: New AR Add Form: Sample field does not filter by Client
 - Issue-2242: New AR Add Form: Local Samplepoints with the same Sampletype from other clients get displayed


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://github.com/bikalims/bika.lims/issues/2237

## Current behavior before PR

Prices were recalculated even if the prices were hidden by Bika setup.

## Desired behavior after PR is merged

Prices are only recalculated if the Prices setting in Bika is enabled.
--
I confirm I have read the [Bika LIMS Developer Guidelines][1] and that I have
tested the PR thoroughly and coded it according to [PEP8][2] standards.

[1]: https://github.com/bikalabs/bika.lims/wiki/Bika-LIMS-Developer-Guidelines

[2]: https://www.python.org/dev/peps/pep-0008
