### PR TITLE
Number (getResultsTotalCount) of results not recording correctly

### DIFF
--- a/bika/lims/exportimport/instruments/resultsimport.py
+++ b/bika/lims/exportimport/instruments/resultsimport.py
@@ -111,8 +111,7 @@ class InstrumentResultsFileParser(Logger):
         """
         count = 0
         for val in self.getRawResults().values():
-            for row in val:
-                count += len(val)
+            count += len(val)
         return count
 
     def getAnalysesTotalCount(self):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
      On an instrument import number of results showed is not correctly
      End of file reached successfully: 2 objects, 7 analyses, 98 results
Linked issue: https://github.com/bikalims/bika.lims/issues/

## Current behavior before PR
      End of file reached successfully: 2 objects, 7 analyses, 98 results
## Desired behavior after PR is merged
     End of file reached successfully: 2 objects, 7 analyses, 14 results
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
