### PR TITLE
LIMS-2696: Factor worksheet folderitem into separate method for each column

### DIFF
--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -1099,6 +1099,8 @@ class BikaListingView(BrowserView):
             item = self.folderitem(obj, results_dict, idx)
             if item:
                 results.append(item)
+                # Populate column values using self.column_* methods
+                self._call_column_getters(item, obj)
                 idx += 1
 
         # Need manual_sort?
@@ -1109,6 +1111,22 @@ class BikaListingView(BrowserView):
                                           y.get(self.manual_sort_on, '')))
 
         return results
+
+    def _call_column_getters(self, item, obj):
+        """Populate column values using self.column_* methods.  These methods
+        are called if the column is displayed.
+        """
+        # columns to display combines defaults and cookie value
+        cookie_cols = self.get_toggle_cols()
+        for col_title, col in self.columns.items():
+            if not (col_title in cookie_cols or col['toggle']):
+                continue
+            if not hasattr(self, "column_%s" % col_title):
+                continue
+            fun = getattr(self, "column_%s" % col_title)
+            # call each column_* function
+            if callable(fun):
+                fun(item, obj)
 
     def contents_table(self, table_only=False):
         """ If you set table_only to true, then nothing outside of the

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.4.0 (unreleased)
 ------------------
 
+- LIMS-2696: bika_listing performance: refactor folderitem to use column_* methods
 - BC-147: Default empty WS view should list on due date
 - Issue-2103: WS Templates not offered for selection
 - Instrument selection for creating WSs does not work


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

If the column is flagged as visible in a cookie, or toggle:True in bika_listing.columns, only then, if bika_listing.column_<col_name> is defined and callable, it is called.  This is done in bika_listing so that self.column_* will always be called after the rest of folderitem(s) has been run. Refactoring folderitem(s) in this way allows folderitem to only run the code that's required.

## Current behavior before PR

bika_listing is slow

## Desired behavior after PR is merged

step by step, it must get better, especially in such easy little ways.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
