### PR TITLE
Issue-2258: New AR Add Form: Required reference fields are flagged as missing and the form does not proceed

### DIFF
--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,3 +1,9 @@
+3.2.1 (unreleased)
+------------------
+
+- Issue-2258: New AR Add Form: Required reference fields are flagged as missing and the form does not proceed
+
+
 3.2.1rc3 (2017-10-02)
 ---------------------
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@
 import os
 from setuptools import setup, find_packages
 
-version = '3.2.1rc3'
+version = '3.2.1'
 
 
 def read(*rnames):


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/bikalims/bika.lims/issues/2258

## Current behavior before PR

Required reference fields are flagged as missing in the AR Add form, even if they have a value set.

## Desired behavior after PR is merged

Validation of required reference fields pass in AR Add if references are present

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
