### PR TITLE
Issue-2225: Worksheet "Show More" Button in Listing View breaks the whole Layout 

### DIFF
--- a/bika/lims/browser/worksheet/views/add_analyses.py
+++ b/bika/lims/browser/worksheet/views/add_analyses.py
@@ -129,6 +129,8 @@ class AddAnalysesView(BikaListingView):
 
         if self.request.get('table_only', '') == self.form_id:
             return self.contents_table()
+        elif self.request.get('rows_only', '') == self.form_id:
+            return self.contents_table()
         else:
             return self.template()
 

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.2.1 (unreleased)
 ------------------
 
+- Issue-2225: Worksheet "Show More" Button in Listing View breaks the whole Layout
 - Issue-2258: New AR Add Form: Required reference fields are flagged as missing and the form does not proceed
 
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/bikalims/bika.lims/issues/2225

## Current behavior before PR

Clicking on "Show more" breaks the entire listing table

## Desired behavior after PR is merged

Clicking on "Show more" works

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
