### PR TITLE
Issue-2263/-2264: Bika Listing: Instrument Calibration Table fixes

### DIFF
--- a/bika/lims/browser/instrument.py
+++ b/bika/lims/browser/instrument.py
@@ -508,7 +508,14 @@ class InstrumentCertificationsViewView(BrowserView):
     _certificationsview = None
 
     def __call__(self):
-        return self.template()
+        view = self.get_certifications_view()
+        view._process_request()
+        if self.request.get('table_only', '') == view.form_id:
+            return view.contents_table()
+        elif self.request.get('rows_only', '') == view.form_id:
+            return view.contents_table()
+        else:
+            return self.template()
 
     def get_certifications_table(self):
         """ Returns the table of Certifications
@@ -556,7 +563,7 @@ class InstrumentCertificationsView(BikaListingView):
         ]
         self.allow_edit = False
         self.show_select_column = False
-        self.show_workflow_action_buttons = False
+        self.show_workflow_action_buttons = True
         uids = [c.UID() for c in self.context.getCertifications()]
         self.catalog = 'portal_catalog'
         self.contentFilter = {'UID': uids, 'sort_on': 'sortable_title'}

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,8 @@
 3.2.1 (unreleased)
 ------------------
 
+- Issue-2264: Bika Listing: Instrument Calibration Table only shows 30 Items w/o pagination controls
+- Issue-2263: Bika Listing: Clicking on the sorting-header of Instrument Calibrations re-renders the entire page recursively
 - Issue-2225: Worksheet "Show More" Button in Listing View breaks the whole Layout
 - Issue-2258: New AR Add Form: Required reference fields are flagged as missing and the form does not proceed
 


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issues:
- https://github.com/bikalims/bika.lims/issues/2263
- https://github.com/bikalims/bika.lims/issues/2264

## Current behavior before PR

- Calibration table breaks if the user clicks on the sorting header
- Calibration table has no paging controls and shows only 30 Items

## Desired behavior after PR is merged

Calibration listing table works as expected

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
