### PR TITLE
Issue-2268: Show the Unit in Manage Analyses View

### DIFF
--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -5,27 +5,24 @@
 # Copyright 2011-2017 by it's authors.
 # Some rights reserved. See LICENSE.txt, AUTHORS.txt.
 
-from AccessControl import getSecurityManager
-from bika.lims import bikaMessageFactory as _
-from bika.lims.utils import t, dicts_to_dict
-from bika.lims.browser.bika_listing import BikaListingView
-from bika.lims.browser.sample import SamplePartitionsView
-from bika.lims.content.analysisrequest import schema as AnalysisRequestSchema
-from bika.lims.permissions import *
-from bika.lims.utils import logged_in_client
-from bika.lims.utils import to_utf8
-from bika.lims.workflow import doActionFor
-from DateTime import DateTime
-from Products.Archetypes import PloneMessageFactory as PMF
-from plone.app.content.browser.interfaces import IFolderContentsView
-from plone.app.layout.globals.interfaces import IViewView
-from Products.CMFCore.utils import getToolByName
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+import json
+
 from zope.i18n.locales import locales
 from zope.interface import implements
 
-import json
-import plone
+from plone.app.content.browser.interfaces import IFolderContentsView
+from plone.app.layout.globals.interfaces import IViewView
+
+from Products.CMFCore.utils import getToolByName
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
+from bika.lims import bikaMessageFactory as _
+from bika.lims.utils import t
+from bika.lims.utils import dicts_to_dict
+from bika.lims.browser.bika_listing import BikaListingView
+from bika.lims.browser.sample import SamplePartitionsView
+from bika.lims.utils import logged_in_client
+
 
 class AnalysisRequestAnalysesView(BikaListingView):
     implements(IFolderContentsView, IViewView)
@@ -35,9 +32,11 @@ class AnalysisRequestAnalysesView(BikaListingView):
     def __init__(self, context, request):
         super(AnalysisRequestAnalysesView, self).__init__(context, request)
         self.catalog = "bika_setup_catalog"
-        self.contentFilter = {'portal_type': 'AnalysisService',
-                              'sort_on': 'sortable_title',
-                              'inactive_state': 'active', }
+        self.contentFilter = {
+            'portal_type': 'AnalysisService',
+            'sort_on': 'sortable_title',
+            'inactive_state': 'active',
+        }
         self.context_actions = {}
         self.icon = self.portal_url + "/++resource++bika.lims.images/analysisrequest_big.png"
         self.title = self.context.Title()
@@ -57,23 +56,39 @@ class AnalysisRequestAnalysesView(BikaListingView):
             self.category_index = 'getCategoryTitle'
 
         self.columns = {
-            'Title': {'title': _('Service'),
-                      'index': 'sortable_title',
-                      'sortable': False, },
-            'Hidden': {'title': _('Hidden'),
-                       'sortable': False,
-                       'type': 'boolean', },
-            'Price': {'title': _('Price'),
-                      'sortable': False, },
-            'Priority': {'title': _('Priority'),
-                         'sortable': False,
-                         'index': 'Priority',
-                         'toggle': True },
-            'Partition': {'title': _('Partition'),
-                          'sortable': False, },
-            'min': {'title': _('Min')},
-            'max': {'title': _('Max')},
-            'error': {'title': _('Permitted Error %')},
+            'Title': {
+                'title': _('Service'),
+                'index': 'sortable_title',
+                'sortable': False,
+            },
+            'Hidden': {
+                'title': _('Hidden'),
+                'sortable': False,
+                'type': 'boolean',
+            },
+            'Price': {
+                'title': _('Price'),
+                'sortable': False,
+            },
+            'Priority': {
+                'title': _('Priority'),
+                'sortable': False,
+                'index': 'Priority',
+                'toggle': True,
+            },
+            'Partition': {
+                'title': _('Partition'),
+                'sortable': False,
+            },
+            'min': {
+                'title': _('Min'),
+            },
+            'max': {
+                'title': _('Max'),
+            },
+            'error': {
+                'title': _('Permitted Error %'),
+            },
         }
 
         columns = ['Title', 'Hidden', ]
@@ -91,14 +106,15 @@ class AnalysisRequestAnalysesView(BikaListingView):
             columns.append('error')
 
         self.review_states = [
-            {'id': 'default',
-             'title': _('All'),
-             'contentFilter': {},
-             'columns': columns,
-             'transitions': [{'id': 'empty'}, ],  # none
-             'custom_actions': [{'id': 'save_analyses_button',
-                                 'title': _('Save')}, ],
-             },
+            {
+                'id': 'default',
+                'title': _('All'),
+                'contentFilter': {},
+                'columns': columns,
+                'transitions': [{'id': 'empty'}, ],  # none
+                'custom_actions': [{'id': 'save_analyses_button',
+                                    'title': _('Save')}, ],
+            },
         ]
 
         # Create Partitions View for this ARs sample
@@ -140,7 +156,7 @@ class AnalysisRequestAnalysesView(BikaListingView):
         return json.dumps(rr_dict_by_service_uid)
 
     def get_spec_from_ar(self, ar, keyword):
-        empty = {'min': '', 'max': '', 'error': '', 'keyword':keyword}
+        empty = {'min': '', 'max': '', 'error': '', 'keyword': keyword}
         spec = ar.getResultsRange()
         if spec:
             return dicts_to_dict(spec, 'keyword').get(keyword, empty)
@@ -192,7 +208,7 @@ class AnalysisRequestAnalysesView(BikaListingView):
                       for o in parts
                       if wf.getInfoFor(o, 'cancellation_state', '') == 'active']
         for x in range(len(items)):
-            if not 'obj' in items[x]:
+            if 'obj' not in items[x]:
                 continue
             obj = items[x]['obj']
 
@@ -243,9 +259,9 @@ class AnalysisRequestAnalysesView(BikaListingView):
                 items[x]['Partition'] = part.Title()
                 spec = self.get_spec_from_ar(self.context,
                                              analysis.getService().getKeyword())
-                items[x]["min"] = spec.get("min",'')
-                items[x]["max"] = spec.get("max",'')
-                items[x]["error"] = spec.get("error",'')
+                items[x]["min"] = spec.get("min", '')
+                items[x]["max"] = spec.get("max", '')
+                items[x]["error"] = spec.get("error", '')
                 # Add priority premium
                 items[x]['Price'] = analysis.getPrice()
                 priority = analysis.getPriority()
@@ -288,7 +304,6 @@ class AnalysisRequestAnalysesView(BikaListingView):
                 )
             if after_icons:
                 items[x]['after']['Title'] = after_icons
-
 
             # Display analyses for this Analysis Service in results?
             ser = self.context.getAnalysisServiceSettings(obj.UID())

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -63,6 +63,10 @@ class AnalysisRequestAnalysesView(BikaListingView):
                 'index': 'sortable_title',
                 'sortable': False,
             },
+            'Unit': {
+                'title': _('Unit'),
+                'sortable': False,
+            },
             'Hidden': {
                 'title': _('Hidden'),
                 'sortable': False,
@@ -93,7 +97,7 @@ class AnalysisRequestAnalysesView(BikaListingView):
             },
         }
 
-        columns = ['Title', 'Hidden', ]
+        columns = ['Title', 'Unit', 'Hidden', ]
         ShowPrices = self.context.bika_setup.getShowPrices()
         if ShowPrices:
             columns.append('Price')
@@ -322,6 +326,7 @@ class AnalysisRequestAnalysesView(BikaListingView):
             ser = self.context.getAnalysisServiceSettings(obj.UID())
             item['allow_edit'] = ['Hidden', ]
             item['Hidden'] = ser.get('hidden', obj.getHidden())
+            item['Unit'] = obj.getUnit()
 
         self.categories.sort()
         return items

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -16,12 +16,14 @@ from plone.app.layout.globals.interfaces import IViewView
 from Products.CMFCore.utils import getToolByName
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
-from bika.lims import bikaMessageFactory as _
+from bika.lims import api
+from bika.lims import logger
 from bika.lims.utils import t
 from bika.lims.utils import dicts_to_dict
+from bika.lims.utils import logged_in_client
+from bika.lims import bikaMessageFactory as _
 from bika.lims.browser.bika_listing import BikaListingView
 from bika.lims.browser.sample import SamplePartitionsView
-from bika.lims.utils import logged_in_client
 
 
 class AnalysisRequestAnalysesView(BikaListingView):
@@ -134,24 +136,42 @@ class AnalysisRequestAnalysesView(BikaListingView):
 
         self.parts = p.contents_table()
 
+    def get_service_by_keyword(self, keyword, default=None):
+        """Get a service by keyword
+        """
+        logger.info("Get service by keyword={}".format(keyword))
+        bsc = api.get_tool("bika_setup_catalog")
+        results = bsc(portal_type='AnalysisService',
+                      getKeyword=keyword)
+        if not results:
+            logger.exception("No Analysis Service found for Keyword '{}'. "
+                             "Related: LIMS-1614".format(keyword))
+            return default
+        elif len(results) > 1:
+            logger.exception("More than one Analysis Service found for Keyword '{}'. "
+                             .format(keyword))
+            return default
+        else:
+            return api.get_object(results[0])
+
     def getResultsRange(self):
         """Return the AR Specs sorted by Service UID, so that the JS can
         work easily with the values.
         """
-        bsc = self.bika_setup_catalog
+
         rr_dict_by_service_uid = {}
         rr = self.context.getResultsRange()
+
         for r in rr:
-            keyword = r['keyword']
-            try:
-                service_uid = bsc(portal_type='AnalysisService',
-                                  getKeyword=keyword)[0].UID
-                rr_dict_by_service_uid[service_uid] = r
-            except IndexError:
-                from bika.lims import logger
-                error = "No Analysis Service found for Keyword '%s'. "\
-                        "Related: LIMS-1614"
-                logger.exception(error, keyword)
+            uid = r.get("uid", None)
+            if not uid:
+                # get the AS by keyword
+                keyword = r.get("keyword")
+                service = self.get_service_by_keyword(keyword, None)
+                if service is not None:
+                    uid = api.get_uid(service)
+            if uid:
+                rr_dict_by_service_uid[uid] = r
 
         return json.dumps(rr_dict_by_service_uid)
 

--- a/bika/lims/browser/analysisrequest/manage_analyses.py
+++ b/bika/lims/browser/analysisrequest/manage_analyses.py
@@ -207,71 +207,64 @@ class AnalysisRequestAnalysesView(BikaListingView):
                        'ResultText': o.getId()}
                       for o in parts
                       if wf.getInfoFor(o, 'cancellation_state', '') == 'active']
-        for x in range(len(items)):
-            if 'obj' not in items[x]:
+
+        for item in items:
+            if 'obj' not in item:
                 continue
-            obj = items[x]['obj']
+            obj = item['obj']
 
             cat = obj.getCategoryTitle()
-            items[x]['category'] = cat
+            item['category'] = cat
             if cat not in self.categories:
                 self.categories.append(cat)
 
-            items[x]['selected'] = items[x]['uid'] in self.selected
+            item['selected'] = item['uid'] in self.selected
 
-            items[x]['class']['Title'] = 'service_title'
+            item['class']['Title'] = 'service_title'
 
             # js checks in row_data if an analysis may be removed.
             row_data = {}
-            # keyword = obj.getKeyword()
-            # if keyword in review_states.keys() \
-            #    and review_states[keyword] not in ['sample_due',
-            #                                       'to_be_sampled',
-            #                                       'to_be_preserved',
-            #                                       'sample_received',
-            #                                       ]:
-            #     row_data['disabled'] = True
-            items[x]['row_data'] = json.dumps(row_data)
+            item['row_data'] = json.dumps(row_data)
 
             calculation = obj.getCalculation()
-            items[x]['Calculation'] = calculation and calculation.Title()
+            item['Calculation'] = calculation and calculation.Title()
 
             locale = locales.getLocale('en')
             currency = self.context.bika_setup.getCurrency()
             symbol = locale.numbers.currencies[currency].symbol
-            items[x]['before']['Price'] = symbol
-            items[x]['Price'] = obj.getPrice()
-            items[x]['class']['Price'] = 'nowrap'
-            items[x]['Priority'] = ''
+            item['before']['Price'] = symbol
+            item['Price'] = obj.getPrice()
+            item['class']['Price'] = 'nowrap'
+            item['Priority'] = ''
 
-            if items[x]['selected']:
-                items[x]['allow_edit'] = ['Partition', 'min', 'max', 'error']
+            if item['selected']:
+                item['allow_edit'] = ['Partition', 'min', 'max', 'error']
                 if not logged_in_client(self.context):
-                    items[x]['allow_edit'].append('Price')
+                    item['allow_edit'].append('Price')
 
-            items[x]['required'].append('Partition')
-            items[x]['choices']['Partition'] = partitions
+            item['required'].append('Partition')
+            item['choices']['Partition'] = partitions
 
             if obj.UID() in self.analyses:
                 analysis = self.analyses[obj.UID()]
                 part = analysis.getSamplePartition()
                 part = part and part or obj
-                items[x]['Partition'] = part.Title()
+                item['Partition'] = part.Title()
                 spec = self.get_spec_from_ar(self.context,
                                              analysis.getService().getKeyword())
-                items[x]["min"] = spec.get("min", '')
-                items[x]["max"] = spec.get("max", '')
-                items[x]["error"] = spec.get("error", '')
+                item["min"] = spec.get("min", '')
+                item["max"] = spec.get("max", '')
+                item["error"] = spec.get("error", '')
                 # Add priority premium
-                items[x]['Price'] = analysis.getPrice()
+                item['Price'] = analysis.getPrice()
                 priority = analysis.getPriority()
-                items[x]['Priority'] = priority and priority.Title() or ''
+                item['Priority'] = priority and priority.Title() or ''
             else:
-                items[x]['Partition'] = ''
-                items[x]["min"] = ''
-                items[x]["max"] = ''
-                items[x]["error"] = ''
-                items[x]["Priority"] = ''
+                item['Partition'] = ''
+                item["min"] = ''
+                item["max"] = ''
+                item["error"] = ''
+                item["Priority"] = ''
 
             after_icons = ''
             if obj.getAccredited():
@@ -303,12 +296,12 @@ class AnalysisRequestAnalysesView(BikaListingView):
                     t(_('Attachment not permitted'))
                 )
             if after_icons:
-                items[x]['after']['Title'] = after_icons
+                item['after']['Title'] = after_icons
 
             # Display analyses for this Analysis Service in results?
             ser = self.context.getAnalysisServiceSettings(obj.UID())
-            items[x]['allow_edit'] = ['Hidden', ]
-            items[x]['Hidden'] = ser.get('hidden', obj.getHidden())
+            item['allow_edit'] = ['Hidden', ]
+            item['Hidden'] = ser.get('hidden', obj.getHidden())
 
         self.categories.sort()
         return items

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.4.0 (unreleased)
 ------------------
 
+- Issue-2268: Show the Unit in Manage Analyses View
 - BC-147: Default empty WS view should list on due date
 - Issue-2103: WS Templates not offered for selection
 - Instrument selection for creating WSs does not work


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/bikalims/bika.lims/issues/2268

## Current behavior before PR

- Unit is not displayed in the "Manage Analyses" view

## Desired behavior after PR is merged

- Unit column is displayed per default
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
