### PR TITLE
Issue-2270:Setting 2 or more CCContacts in AR view produces a Traceback on Save

### DIFF
--- a/bika/lims/browser/header_table.py
+++ b/bika/lims/browser/header_table.py
@@ -37,9 +37,14 @@ class HeaderTableView(BrowserView):
             for field in fields:
                 fieldname = field.getName()
                 if fieldname in form:
-                    if fieldname + "_uid" in form:
-                        # references (process_form would normally do *_uid trick)
-                        field.getMutator(self.context)(form[fieldname + "_uid"])
+                    # Handle (multiValued) reference fields
+                    # https://github.com/bikalims/bika.lims/issues/2270
+                    uid_fieldname = "{}_uid".format(fieldname)
+                    if uid_fieldname in form:
+                        value = form[uid_fieldname]
+                        if field.multiValued:
+                            value = value.split(",")
+                        field.getMutator(self.context)(value)
                     else:
                         # other fields
                         field.getMutator(self.context)(form[fieldname])

--- a/bika/lims/browser/header_table.py
+++ b/bika/lims/browser/header_table.py
@@ -8,20 +8,21 @@
 """ARs and Samples use HeaderTable to display object fields in their custom
 view and edit screens.
 """
-from Products.CMFCore.utils import getToolByName
 
-from bika.lims.browser import BrowserView
-from bika.lims.interfaces import IHeaderTableFieldRenderer
-from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
-from Products.CMFPlone import PloneMessageFactory as _p
-from bika.lims.utils import getHiddenAttributesForClass
-from bika.lims.workflow import doActionFor
-from bika.lims.utils import t
-from bika.lims import bikaMessageFactory as _
 from zope.component import getAdapter
-from AccessControl import getSecurityManager
-from AccessControl.Permissions import view
 from zope.component.interfaces import ComponentLookupError
+
+from AccessControl.Permissions import view
+from AccessControl import getSecurityManager
+
+from Products.CMFPlone import PloneMessageFactory as _p
+from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
+
+from bika.lims.utils import t
+from bika.lims.browser import BrowserView
+from bika.lims import bikaMessageFactory as _
+from bika.lims.interfaces import IHeaderTableFieldRenderer
+
 
 class HeaderTableView(BrowserView):
 
@@ -81,10 +82,12 @@ class HeaderTableView(BrowserView):
         else:
             if field.getType().find("ool") > -1:
                 value = field.get(self.context)
-                ret = {'fieldName': fieldname,
-                       'mode': 'structure',
-                       'html': t(_('Yes')) if value else t(_('No'))
+                ret = {
+                    'fieldName': fieldname,
+                    'mode': 'structure',
+                    'html': t(_('Yes')) if value else t(_('No'))
                 }
+
             elif field.getType().find("Reference") > -1:
                 # Prioritize method retrieval over schema's field
                 targets = None
@@ -97,7 +100,7 @@ class HeaderTableView(BrowserView):
 
                 if targets:
                     if not type(targets) == list:
-                        targets = [targets,]
+                        targets = [targets, ]
                     sm = getSecurityManager()
                     if all([sm.checkPermission(view, ta) for ta in targets]):
                         a = ["<a href='%s'>%s</a>" % (target.absolute_url(),
@@ -116,9 +119,10 @@ class HeaderTableView(BrowserView):
                            'html': ''}
             elif field.getType().lower().find('datetime') > -1:
                 value = field.get(self.context)
-                ret = {'fieldName': fieldname,
-                       'mode': 'structure',
-                       'html': self.ulocalized_time(value, long_format=True)
+                ret = {
+                    'fieldName': fieldname,
+                    'mode': 'structure',
+                    'html': self.ulocalized_time(value, long_format=True)
                 }
         return ret
 

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.2.1 (unreleased)
 ------------------
 
+- Issue-2270: Setting 2 or more CCContacts in AR view produces a Traceback on Save
 - Issue-2264: Bika Listing: Instrument Calibration Table only shows 30 Items w/o pagination controls
 - Issue-2263: Bika Listing: Clicking on the sorting-header of Instrument Calibrations re-renders the entire page recursively
 - Issue-2225: Worksheet "Show More" Button in Listing View breaks the whole Layout


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/bikalims/bika.lims/issues/2270

## Current behavior before PR

Traceback occurs when setting 2 or more CCContacts in AR Table Header and clicking "Save"

## Desired behavior after PR is merged

Values get stored accordingly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
