### PR TITLE
Ensure no counters in the number generator before initialising id server

### DIFF
--- a/bika/lims/numbergenerator.py
+++ b/bika/lims/numbergenerator.py
@@ -74,6 +74,7 @@ class NumberGenerator(object):
         """
         storage = self.storage
 
+        logger.debug("NUMBER before => %s" % storage.get(key, '-'))
         try:
             logger.debug("*** consecutive number lock acquire ***")
             lock.acquire()
@@ -87,7 +88,7 @@ class NumberGenerator(object):
             self.storage._p_changed = True
             lock.release()
 
-        logger.debug("NUMBER => %d" % storage[key])
+        logger.debug("NUMBER after => %s" % storage.get(key, '-'))
         return storage[key]
 
     def generate_number(self, key="default"):

--- a/bika/lims/upgrade/to340.py
+++ b/bika/lims/upgrade/to340.py
@@ -42,8 +42,13 @@ def upgrade(tool):
 
 
 def prepare_number_generator(portal):
-    # Load IDServer defaults
+    number_generator = getUtility(INumberGenerator)
+    if len(number_generator.keys()) > 1:
+        logger.info('Skip number generator initialisation')
+        return
 
+    logger.info('Initialise number generator')
+    # Load IDServer defaults
     config_map = [
         {'context': 'sample',
          'counter_reference': 'AnalysisRequestSample',


### PR DESCRIPTION
# Description of the issue/feature this PR addresses
Re-running upgrade step 3.4.0 on a site that is version 3.4.0 and already has samples will damage the counters in the number generator 

Linked issue: https://github.com/bikalims/bika.lims/issues/2272

## Current behavior before PR
Increment existing counters unnecessarily

## Desired behavior after PR is merged
Leave counters alone.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
