### PR TITLE
ISSUE-2278: Verify calculated results the first time around

### DIFF
--- a/bika/lims/browser/bika_listing.py
+++ b/bika/lims/browser/bika_listing.py
@@ -225,6 +225,16 @@ class WorkflowAction:
         dest = None
         transitioned = []
         workflow = getToolByName(self.context, 'portal_workflow')
+        # NOTE:Calculated result are on the top of the list and because of that
+        # they cannot be transitioned from to_be_verified to verified
+        # because their dependencies have not been transition
+        # so we transition the dependencies first by putting the
+        # calculated results at the end of the list
+        items = sorted(items,
+                key=lambda x: (
+                    hasattr(x, 'calculateResult')
+                    and x.calculateResult(override=True, cascade=True)
+                    is True, x))
 
         # transition selected items from the bika_listing/Table.
         for item in items:

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2682,29 +2682,33 @@ class AnalysisRequest(BaseFolder):
 
         # Check if the analysis request state is to_be_verified
         review_state = workflow.getInfoFor(self, "review_state")
-        if review_state == 'to_be_verified':
-            # This means that all the analyses from this analysis request have
-            # already been transitioned to a 'verified' state, and so the
-            # analysis request itself
-            return True
-        else:
-            # Check if the analyses contained in this analysis request are
-            # verifiable. Only check those analyses not cancelled and that
-            # are not in a kind-of already verified state
-            canbeverified = True
-            omit = ['published', 'retracted', 'rejected', 'verified']
-            for a in self.getAnalyses(full_objects=True):
-                st = workflow.getInfoFor(a, 'cancellation_state', 'active')
-                if st == 'cancelled':
-                    continue
-                st = workflow.getInfoFor(a, 'review_state')
-                if st in omit:
-                    continue
-                # Can the analysis be verified?
-                if not a.isVerifiable(self):
-                    canbeverified = False
-                    break
-            return canbeverified
+        #NOTE: We've commented-out the code below because if the analyses
+        # on the are AR are not all Verified, the Verify transition is
+        # available on the AR, whereas it should not be available
+
+        #if review_state == 'to_be_verified':
+        #    # This means that all the analyses from this analysis request have
+        #    # already been transitioned to a 'verified' state, and so the
+        #    # analysis request itself
+        #    return True
+        #else:
+        #    # Check if the analyses contained in this analysis request are
+        #    # verifiable. Only check those analyses not cancelled and that
+        #    # are not in a kind-of already verified state
+        canbeverified = True
+        omit = ['published', 'retracted', 'rejected', 'verified']
+        for a in self.getAnalyses(full_objects=True):
+            st = workflow.getInfoFor(a, 'cancellation_state', 'active')
+            if st == 'cancelled':
+                continue
+            st = workflow.getInfoFor(a, 'review_state')
+            if st in omit:
+                continue
+            # Can the analysis be verified?
+            if not a.isVerifiable():
+                canbeverified = False
+                break
+        return canbeverified
 
     def isUserAllowedToVerify(self, member):
         """Checks if the specified user has enough privileges to verify the

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.4.0 (unreleased)
 ------------------
 
+- Issue-2278: Verify Calculated Results the first time around
 - Issue-2268: Show the Unit in Manage Analyses View
 - BC-147: Default empty WS view should list on due date
 - Issue-2103: WS Templates not offered for selection


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/bikalims/bika.lims/issues/2278

## Current behavior before PR
    An AR is verifiable but it has analyses that are on to_be_verified state and when its verified it does 
    not verify all its children(analyses)
    Calculated results that are in to_be_verified state do not verify the first time around
## Desired behavior after PR is merged
     Calculated results that are in to_be_verified state should verify the first time around
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
