### PR TITLE
Issue-2280: Fix publication preferences for CC Contacts

### DIFF
--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -980,7 +980,7 @@ class AnalysisRequestPublishView(BrowserView):
         for cc in ar.getCCContact():
             recips.append({'title': to_utf8(cc.Title()),
                            'email': cc.getEmailAddress(),
-                           'pubpref': contact.getPublicationPreference()})
+                           'pubpref': cc.getPublicationPreference()})
 
         return recips
 

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.2.1 (unreleased)
 ------------------
 
+- Issue-2280: CC Contacts don't get notified on AR Publication
 - Issue-2270: Setting 2 or more CCContacts in AR view produces a Traceback on Save
 - Issue-2264: Bika Listing: Instrument Calibration Table only shows 30 Items w/o pagination controls
 - Issue-2263: Bika Listing: Clicking on the sorting-header of Instrument Calibrations re-renders the entire page recursively


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

This fixes an issue where no emails were sent to CC Contacts
if the primary contact has no publication preferences set.

Linked issue: https://github.com/bikalims/bika.lims/issues/2280

## Current behavior before PR

CC Contacts received _no_ email if the primary contact has _no_ publication preferences set.

## Desired behavior after PR is merged

CC Contacts receive email according to their own publication preferences.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
