### PR TITLE
Issue-2282: Don't require all ARs if only the contact is set

### DIFF
--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1670,9 +1670,16 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
             if record.get("Client", False):
                 required_fields.pop('Client', None)
 
+            # Contacts get pre-filled out if only one contact exists.
+            # We won't force those columns with only the Contact filled out to be required.
+            contact = required_fields.pop("Contact", None)
+
             # None of the required fields are filled, skip this record
             if not any(required_fields.values()):
                 continue
+
+            # Re-add the Contact
+            required_fields["Contact"] = contact
 
             # Missing required fields
             missing = [f for f in required_fields if not record.get(f, None)]

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.2.1 (unreleased)
 ------------------
 
+- Issue-2282: Don't force columns if the Contact fields got auto-filled on load
 - Issue-2280: CC Contacts don't get notified on AR Publication
 - Issue-2270: Setting 2 or more CCContacts in AR view produces a Traceback on Save
 - Issue-2264: Bika Listing: Instrument Calibration Table only shows 30 Items w/o pagination controls


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/bikalims/bika.lims/issues/2282

## Current behavior before PR

AR Add columns where only the Contact got set per default, require all fields

## Desired behavior after PR is merged

AR Add columns where only the Contact got set per default, are not required unless another required field got set.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
