### PR TITLE
Issue-2288: Fixed AR Copy from rejected ARs has missing fields

### DIFF
--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -336,6 +336,17 @@ class AnalysisRequestAddView(BrowserView):
             return parent
         return None
 
+    def get_parent_ar(self, ar):
+        """Returns the parent AR
+        """
+        parent = ar.getParentAnalysisRequest()
+        while True:
+            pparent = parent.getParentAnalysisRequest()
+            if pparent is None:
+                break
+            parent = pparent
+        return parent or ar
+
     def generate_fieldvalues(self, count=1):
         """Returns a mapping of '<fieldname>-<count>' to the default value
         of the field or the field value of the source AR
@@ -352,12 +363,14 @@ class AnalysisRequestAddView(BrowserView):
         # generate fields for all requested ARs
         for arnum in range(count):
             source = copy_from.get(arnum)
+            parent = self.get_parent_ar(source)
             for field in fields:
                 value = None
                 fieldname = field.getName()
                 if source and fieldname not in SKIP_FIELD_ON_COPY:
                     # get the field value stored on the source
-                    value = self.get_field_value(field, source)
+                    context = parent or source
+                    value = self.get_field_value(field, context)
                 else:
                     # get the default value of this field
                     value = self.get_default_value(field, ar_context)

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.2.1 (unreleased)
 ------------------
 
+- Issue-2288: AR Copy from rejected AR is has missing fields
 - Issue-2282: Don't force columns if the Contact fields got auto-filled on load
 - Issue-2280: CC Contacts don't get notified on AR Publication
 - Issue-2270: Setting 2 or more CCContacts in AR view produces a Traceback on Save


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/bikalims/bika.lims/issues/2288

## Current behavior before PR

Missing Client and Profiles field if the source AR was rejected

## Desired behavior after PR is merged

All fields are copied even if the source AR was rejected (`-R02`, `-R03` etc.)

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
