### PR TITLE
Add CCEmails to recipients for AR publication reports

### DIFF
--- a/bika/lims/browser/analysisrequest/publish.py
+++ b/bika/lims/browser/analysisrequest/publish.py
@@ -982,6 +982,20 @@ class AnalysisRequestPublishView(BrowserView):
                            'email': cc.getEmailAddress(),
                            'pubpref': cc.getPublicationPreference()})
 
+        # CC Emails
+        # https://github.com/bikalims/bika.lims/issues/2292
+        plone_utils = getToolByName(self.context, "plone_utils")
+        ccemails = map(lambda x: x.strip(), ar.getCCEmails().split(","))
+        for ccemail in ccemails:
+            # Better do that with a field validator
+            if not plone_utils.validateSingleEmailAddress(ccemail):
+                logger.warn("Skipping invalid email address '{}'".format(ccemail))
+                continue
+            recips.append({
+                'title': ccemail,
+                'email': ccemail,
+                'pubpref': ('email', 'pdf', ),})
+
         return recips
 
     def get_mail_subject(self, ar):

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.2.1 (unreleased)
 ------------------
 
+- Issue-2292: CCEmails are nowhere used to send Emails out of the LIMS
 - Issue-2288: AR Copy from rejected AR is has missing fields
 - Issue-2282: Don't force columns if the Contact fields got auto-filled on load
 - Issue-2280: CC Contacts don't get notified on AR Publication


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/bikalims/bika.lims/issues/2292

## Current behavior before PR

CCEmails don't get publication reports via email

## Desired behavior after PR is merged

CCEmails receive publication reports as HTML and attached PDF

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
