### PR TITLE
Allow year in any portal type's ID format string

### DIFF
--- a/bika/lims/docs/IDServer.rst
+++ b/bika/lims/docs/IDServer.rst
@@ -44,9 +44,13 @@ Functional Helpers::
     >>> def timestamp(format="%Y-%m-%d"):
     ...     return DateTime().strftime(format)
 
+    >>> def timestamp(format="%Y-%m-%d"):
+    ...     return DateTime().strftime(format)
+
 Variables::
 
     >>> date_now = timestamp()
+    >>> year = date_now.split('-')[0][2:]
     >>> sample_date = DateTime(2017, 1, 31)
     >>> portal = self.portal
     >>> request = self.request
@@ -126,7 +130,13 @@ Set up `ID Server` configuration::
     ...             'form': '{sampleId}-P{seq:d}',
     ...             'portal_type': 'SamplePartition',
     ...             'sequence_type': 'counter',
-    ...             'value': ''}
+    ...             'value': ''},
+    ...            {'form': 'B{year}-{seq:04d}',
+    ...             'portal_type': 'Batch',
+    ...             'prefix': 'batch',
+    ...             'sequence_type': 'generated',
+    ...             'split_length': 1,
+    ...             'value': ''},
     ...          ]
 
     >>> bika_setup.setIDFormatting(values)
@@ -177,6 +187,12 @@ Create a third `AnalysisRequest` with existing sample::
     >>> ar = create_analysisrequest(client, request, values, service_uids)
     >>> ar
     <AnalysisRequest at /plone/clients/client-1/water17-0002-R2>
+
+Create a forth `Batch`::
+    >>> batches = self.portal.batches
+    >>> batch = api.create(batches, "Batch", ClientID="RB")
+    >>> batch.getId() == "B{}-0001".format(year)
+    True
 
 Change ID formats and create new `AnalysisRequest`::
     >>> values = [

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -90,11 +90,13 @@ def generateUniqueId(context, parent=False, portal_type=''):
         variables_map = {
             'sampleId': context.getSample().getId(),
             'sample': context.getSample(),
+            'year': DateTime().strftime("%Y")[2:],
         }
     elif portal_type == "SamplePartition":
         variables_map = {
             'sampleId': context.aq_parent.getId(),
             'sample': context.aq_parent,
+            'year': DateTime().strftime("%Y")[2:],
         }
     elif portal_type == "Sample" and parent:
         config = getConfigByPortalType(
@@ -103,6 +105,7 @@ def generateUniqueId(context, parent=False, portal_type=''):
         variables_map = {
             'sampleId': context.getId(),
             'sample': context,
+            'year': DateTime().strftime("%Y")[2:],
         }
     elif portal_type == "Sample":
         sampleDate = None
@@ -124,7 +127,9 @@ def generateUniqueId(context, parent=False, portal_type=''):
                 'sequence_type': 'generated',
                 'prefix': '%s' % portal_type.lower(),
             }
-        variables_map = {}
+        variables_map = {
+            'year': DateTime().strftime("%Y")[2:],
+            }
 
     # Actual id construction starts here
     form = config['form']

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -133,15 +133,20 @@ def generateUniqueId(context, parent=False, portal_type=''):
             context=variables_map[config['context']],
             config=config)
     elif config['sequence_type'] == 'generated':
-        if config.get('split_length', None) == 0:
-            prefix_config = '-'.join(form.split('-')[:-1])
-            prefix = prefix_config.format(**variables_map)
-        elif config.get('split_length', None) > 0:
-            prefix_config = '-'.join(form.split('-')[:config['split_length']])
-            prefix = prefix_config.format(**variables_map)
-        else:
-            prefix = config['prefix']
-        new_seq = number_generator(key=prefix)
+        try:
+            if config.get('split_length', None) == 0:
+                prefix_config = '-'.join(form.split('-')[:-1])
+                prefix = prefix_config.format(**variables_map)
+            elif config.get('split_length', None) > 0:
+                prefix_config = '-'.join(form.split('-')[:config['split_length']])
+                prefix = prefix_config.format(**variables_map)
+            else:
+                prefix = config['prefix']
+            new_seq = number_generator(key=prefix)
+        except KeyError, e:
+            msg = "KeyError in GenerateUniqueId on %s: %s" % (
+                    str(config), e)
+            raise RuntimeError(msg)
     variables_map['seq'] = new_seq + 1
     result = form.format(**variables_map)
     return result


### PR DESCRIPTION
Bugfix

## Current behavior before PR
If you use {year} in the ID format of anything other than Sample you get a KeyError.

## Desired behavior after PR is merged
{year} can be used in IDs of any portal type.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
