### PR TITLE
Normalise ID server results

### DIFF
--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -774,27 +774,7 @@ schema = BikaFolderSchema.copy() + Schema((
         widget=RecordsWidget(
             label=_("Formatting Configuration"),
             allowDelete=True,
-            description=_("""The ID Server in Bika LIMS provides IDs for content items base of the given format specification.
-
-The format string is constructed in the same way as a python format() method
-based predefined variables per content type. The only variable available to all
-type is 'seq'. Currently, 'seq' can be constructed either using number generator
-or a counter of existing items. For generated IDs, one can specify the point at
-which the format string will be split to create the generator key. For counter
-IDs, one must specify the context and the type of counter which is either the
-number of backreferences or the number of contained objects.
-
-Configuration Settings:
-* format:
-  - a python format string constructed from predefined variables like sampleId, client, sampleType.
-  - special variable 'seq' must be positioned last in the format string
-* sequence type: [generated|counter]
-* context: if type counter, provides context the counting function
-* counter type: [backreference|contained]
-* counter reference: a parameter to the counting function
-* prefix: default prefix if none provided in format string
-* split length: the number of parts to be included in the prefix
-""")
+            description=_(" <p>The Bika LIMS ID Server provides unique sequential IDs for objects such as Samples and Worksheets etc, based on a format specified for each content type.</p> <p>The format is constructed similarly to the Python format syntax, using predefined variables per content type, and advancing the IDs through a sequence number, 'seq' and its padding as a number of digits, e.g. '03d' for a sequence of IDs from 001 to 999.</p> <p>Alphanumeric prefixes for IDs are included as is in the formats, e.g. WS for Worksheet in WS-{seq:03d} produces sequential Worksheet IDs: WS-001, WS-002, WS-003 etc.</p> <p></p> <p>Variables that can be used include:<table><tr><th style='width:150px'>Content Type</th><th>Variables</th></tr> <tr><td>Client</td><td>{client}</td></tr> <tr><td>Year</td><td>{year}</td></tr> <tr><td>Sample ID</td><td>{sampleId}</td></tr> <tr><td>Sample Type</td><td>{sampleType}</td></tr> <tr><td>Sample Date</td><td>{sampleDate}</td></tr></table></p><p>Configuration Settings:<ul><li>format: <ul><li>a python format string constructed from predefined variables like sampleId, client, sampleType.</li><li>special variable 'seq' must be positioned last in the format string</li></ul></li><li>sequence type: [generated|counter]</li><li>context: if type counter, provides context the counting function</li><li>counter type: [backreference|contained]</li><li>counter reference: a parameter to the counting function</li><li>prefix: default prefix if none provided in format string</li><li>split length: the number of parts to be included in the prefix</li></ul></p>")
         )
     ),
     BooleanField(

--- a/bika/lims/docs/IDServer.rst
+++ b/bika/lims/docs/IDServer.rst
@@ -44,9 +44,13 @@ Functional Helpers::
     >>> def timestamp(format="%Y-%m-%d"):
     ...     return DateTime().strftime(format)
 
+    >>> def timestamp(format="%Y-%m-%d"):
+    ...     return DateTime().strftime(format)
+
 Variables::
 
     >>> date_now = timestamp()
+    >>> year = date_now.split('-')[0][2:]
     >>> sample_date = DateTime(2017, 1, 31)
     >>> portal = self.portal
     >>> request = self.request
@@ -126,7 +130,13 @@ Set up `ID Server` configuration::
     ...             'form': '{sampleId}-P{seq:d}',
     ...             'portal_type': 'SamplePartition',
     ...             'sequence_type': 'counter',
-    ...             'value': ''}
+    ...             'value': ''},
+    ...            {'form': 'B{year}-{seq:04d}',
+    ...             'portal_type': 'Batch',
+    ...             'prefix': 'batch',
+    ...             'sequence_type': 'generated',
+    ...             'split_length': 1,
+    ...             'value': ''},
     ...          ]
 
     >>> bika_setup.setIDFormatting(values)
@@ -177,6 +187,12 @@ Create a third `AnalysisRequest` with existing sample::
     >>> ar = create_analysisrequest(client, request, values, service_uids)
     >>> ar
     <AnalysisRequest at /plone/clients/client-1/water17-0002-R2>
+
+Create a forth `Batch`::
+    >>> batches = self.portal.batches
+    >>> batch = api.create(batches, "Batch", ClientID="RB")
+    >>> batch.getId() == "B{}-0001".format(year)
+    True
 
 Change ID formats and create new `AnalysisRequest`::
     >>> values = [

--- a/bika/lims/docs/IDServer.rst
+++ b/bika/lims/docs/IDServer.rst
@@ -131,7 +131,7 @@ Set up `ID Server` configuration::
     ...             'portal_type': 'SamplePartition',
     ...             'sequence_type': 'counter',
     ...             'value': ''},
-    ...            {'form': 'B{year}-{seq:04d}',
+    ...            {'form': 'BÖ-{year}-{seq:04d}',
     ...             'portal_type': 'Batch',
     ...             'prefix': 'batch',
     ...             'sequence_type': 'generated',
@@ -191,7 +191,7 @@ Create a third `AnalysisRequest` with existing sample::
 Create a forth `Batch`::
     >>> batches = self.portal.batches
     >>> batch = api.create(batches, "Batch", ClientID="RB")
-    >>> batch.getId() == "B{}-0001".format(year)
+    >>> batch.getId() == "BA-{}-0001".format(year)
     True
 
 Change ID formats and create new `AnalysisRequest`::

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -140,10 +140,14 @@ def generateUniqueId(context, parent=False, portal_type=''):
     elif config['sequence_type'] == 'generated':
         try:
             if config.get('split_length', None) == 0:
-                prefix_config = '-'.join(form.split('-')[:-1])
+                prefix_config = '{}-{}'.format(portal_type.lower(),
+                                               '-'.join(form.split('-')[:-1]),
+                                               )
                 prefix = prefix_config.format(**variables_map)
             elif config.get('split_length', None) > 0:
-                prefix_config = '-'.join(form.split('-')[:config['split_length']])
+                prefix_config = '{}-{}'.format(
+                        portal_type.lower(),
+                        '-'.join(form.split('-')[:config['split_length']]))
                 prefix = prefix_config.format(**variables_map)
             else:
                 prefix = config['prefix']

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -90,11 +90,13 @@ def generateUniqueId(context, parent=False, portal_type=''):
         variables_map = {
             'sampleId': context.getSample().getId(),
             'sample': context.getSample(),
+            'year': DateTime().strftime("%Y")[2:],
         }
     elif portal_type == "SamplePartition":
         variables_map = {
             'sampleId': context.aq_parent.getId(),
             'sample': context.aq_parent,
+            'year': DateTime().strftime("%Y")[2:],
         }
     elif portal_type == "Sample" and parent:
         config = getConfigByPortalType(
@@ -103,6 +105,7 @@ def generateUniqueId(context, parent=False, portal_type=''):
         variables_map = {
             'sampleId': context.getId(),
             'sample': context,
+            'year': DateTime().strftime("%Y")[2:],
         }
     elif portal_type == "Sample":
         sampleDate = None
@@ -124,7 +127,9 @@ def generateUniqueId(context, parent=False, portal_type=''):
                 'sequence_type': 'generated',
                 'prefix': '%s' % portal_type.lower(),
             }
-        variables_map = {}
+        variables_map = {
+            'year': DateTime().strftime("%Y")[2:],
+            }
 
     # Actual id construction starts here
     form = config['form']

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -154,7 +154,7 @@ def generateUniqueId(context, parent=False, portal_type=''):
             raise RuntimeError(msg)
     variables_map['seq'] = new_seq + 1
     result = form.format(**variables_map)
-    return result
+    return api.normalize_id(result)
 
 
 def renameAfterCreation(obj):

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -133,15 +133,20 @@ def generateUniqueId(context, parent=False, portal_type=''):
             context=variables_map[config['context']],
             config=config)
     elif config['sequence_type'] == 'generated':
-        if config.get('split_length', None) == 0:
-            prefix_config = '-'.join(form.split('-')[:-1])
-            prefix = prefix_config.format(**variables_map)
-        elif config.get('split_length', None) > 0:
-            prefix_config = '-'.join(form.split('-')[:config['split_length']])
-            prefix = prefix_config.format(**variables_map)
-        else:
-            prefix = config['prefix']
-        new_seq = number_generator(key=prefix)
+        try:
+            if config.get('split_length', None) == 0:
+                prefix_config = '-'.join(form.split('-')[:-1])
+                prefix = prefix_config.format(**variables_map)
+            elif config.get('split_length', None) > 0:
+                prefix_config = '-'.join(form.split('-')[:config['split_length']])
+                prefix = prefix_config.format(**variables_map)
+            else:
+                prefix = config['prefix']
+            new_seq = number_generator(key=prefix)
+        except KeyError, e:
+            msg = "KeyError in GenerateUniqueId on %s: %s" % (
+                    str(config), e)
+            raise RuntimeError(msg)
     variables_map['seq'] = new_seq + 1
     result = form.format(**variables_map)
     return result

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -116,7 +116,7 @@ def generateUniqueId(context, parent=False, portal_type=''):
         variables_map = {
             'clientId': context.aq_parent.getClientID(),
             'sampleDate': sampleDate,
-            'sampleType': api.normalize_filename(sampleType),
+            'sampleType': sampleType,
             'year': DateTime().strftime("%Y")[2:],
         }
     else:
@@ -154,7 +154,7 @@ def generateUniqueId(context, parent=False, portal_type=''):
             raise RuntimeError(msg)
     variables_map['seq'] = new_seq + 1
     result = form.format(**variables_map)
-    return api.normalize_id(result)
+    return api.normalize_filename(result)
 
 
 def renameAfterCreation(obj):


### PR DESCRIPTION
## Current behavior before PR
* Unnormalised IDs would break the rename of new objects
* Keys in the number generator are not prefixed with anything which can lead to duplicate keys for different portal types

## Desired behavior after PR is merged
* IDs are normalised so new objects are created with not illegal characters.
* Prefix number generator keys with the lowercase of the portal type.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
