### PR TITLE
AN-155 specifications on off

### DIFF
--- a/bika/lims/browser/analyses.py
+++ b/bika/lims/browser/analyses.py
@@ -123,6 +123,9 @@ class AnalysesView(BikaListingView):
                 'index': 'getDueDate',
                 'sortable': False},
         }
+        if not self.is_ar_specs_allowed():
+            if 'Specification' in self.columns:
+                del self.columns['Specification']
 
         self.review_states = [
             {
@@ -145,6 +148,10 @@ class AnalysesView(BikaListingView):
                 ]
             },
         ]
+        if not self.is_ar_specs_allowed():
+            if 'Specification' in self.review_states[0]['columns']:
+                self.review_states[0]['columns'].remove('Specification')
+
         if not context.bika_setup.getShowPartitions():
             self.review_states[0]['columns'].remove('Partition')
 
@@ -152,6 +159,12 @@ class AnalysesView(BikaListingView):
                                            request,
                                            show_categories=context.bika_setup.getCategoriseAnalysisServices(),
                                            expand_all_categories=True)
+
+    def is_ar_specs_allowed(self):
+        """Checks if AR Specs are allowed
+        """
+        bika_setup = api.get_bika_setup()
+        return bika_setup.getEnableARSpecs()
 
     def get_analysis_spec(self, analysis):
         if hasattr(analysis, 'getResultsRange'):

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -473,7 +473,7 @@ class AnalysisRequestAddView(BrowserView):
             visible = self.is_field_visible(field)
             if visible is False and visibility != "hidden":
                 continue
-            if field.__name__ == 'Specification':
+            if field.getName() == 'Specification':
                 if not self.is_ar_specs_allowed():
                     continue
             out.append(field)

--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -473,6 +473,9 @@ class AnalysisRequestAddView(BrowserView):
             visible = self.is_field_visible(field)
             if visible is False and visibility != "hidden":
                 continue
+            if field.__name__ == 'Specification':
+                if not self.is_ar_specs_allowed():
+                    continue
             out.append(field)
         return out
 
@@ -981,6 +984,9 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
                 "getClientUID": [uid],
             },
         }
+        if bika_setup.getDefaultARSpecs() == 'ar_specs':
+            del filter_queries['analysisspecs']
+
         info["filter_queries"] = filter_queries
 
         return info

--- a/bika/lims/browser/analysisrequest/view.py
+++ b/bika/lims/browser/analysisrequest/view.py
@@ -17,6 +17,7 @@ from zope.interface import implements
 from plone.app.layout.globals.interfaces import IViewView
 
 from bika.lims import bikaMessageFactory as _
+from bika.lims import api
 from bika.lims.utils import t
 from bika.lims.browser import BrowserView
 from bika.lims.browser.analyses import AnalysesView
@@ -358,10 +359,19 @@ class AnalysisRequestViewView(BrowserView):
         cats = self.getDefaultCategories()
         return [cat.UID() for cat in cats]
 
+    def is_ar_specs_allowed(self):
+        """Checks if AR Specs are allowed
+        """
+        bika_setup = api.get_bika_setup()
+        return bika_setup.getEnableARSpecs()
+
     def getDefaultSpec(self):
         """ Returns 'lab' or 'client' to set the initial value of the
             specification radios
         """
+        if not self.is_ar_specs_allowed():
+            return []
+
         mt = getToolByName(self.context, 'portal_membership')
         pg = getToolByName(self.context, 'portal_groups')
         member = mt.getAuthenticatedMember()

--- a/bika/lims/browser/header_table.py
+++ b/bika/lims/browser/header_table.py
@@ -18,6 +18,7 @@ from AccessControl import getSecurityManager
 from Products.CMFPlone import PloneMessageFactory as _p
 from Products.Five.browser.pagetemplatefile import ViewPageTemplateFile
 
+from bika.lims import api
 from bika.lims.utils import t
 from bika.lims.browser import BrowserView
 from bika.lims import bikaMessageFactory as _
@@ -139,6 +140,10 @@ class HeaderTableView(BrowserView):
         prominent = []
         for field in self.context.Schema().fields():
             fieldname = field.getName()
+            if fieldname == 'Specification':
+                if not self.is_ar_specs_allowed():
+                    continue
+
             state = field.widget.isVisible(self.context, 'header_table', default='invisible', field=field)
             if state == 'invisible':
                 continue
@@ -153,3 +158,9 @@ class HeaderTableView(BrowserView):
                 elif field.widget.isVisible(self.context, 'view', default='invisible', field=field) == 'visible':
                     ret.append(self.render_field_view(field))
         return prominent, self.three_column_list(ret)
+
+    def is_ar_specs_allowed(self):
+        """Checks if AR Specs are allowed
+        """
+        bika_setup = api.get_bika_setup()
+        return bika_setup.getEnableARSpecs()

--- a/bika/lims/content/analysisrequest.py
+++ b/bika/lims/content/analysisrequest.py
@@ -2464,6 +2464,12 @@ class AnalysisRequest(BaseFolder):
         else:
             return ''
 
+    def is_ar_specs_allowed(self):
+        """Checks if AR Specs are allowed
+        """
+        bika_setup = api.get_bika_setup()
+        return bika_setup.getEnableARSpecs()
+
     def setResultsRange(self, value=None):
         """Sets the spec values for this AR.
         1 - Client specs where (spec.Title) matches (ar.SampleType.Title)
@@ -2481,6 +2487,8 @@ class AnalysisRequest(BaseFolder):
 
         Value will be stored in ResultsRange field as list of dictionaries
         """
+        if not self.is_ar_specs_allowed():
+            return []
         rr = {}
         sample = self.getSample()
         if not sample:
@@ -2493,7 +2501,8 @@ class AnalysisRequest(BaseFolder):
         for folder in self.aq_parent, self.bika_setup.bika_analysisspecs:
             proxies = bsc(portal_type='AnalysisSpec',
                           getSampleTypeTitle=stt,
-                          ClientUID=folder.UID())
+                          ClientUID=folder.UID(),
+                          inactive_state='active')
             if proxies:
                 rr = dicts_to_dict(proxies[0].getObject().getResultsRange(),
                                    'keyword')

--- a/bika/lims/content/bikasetup.py
+++ b/bika/lims/content/bikasetup.py
@@ -349,7 +349,7 @@ schema = BikaFolderSchema.copy() + Schema((
         schemata="Analyses",
         default=True,
         widget=BooleanWidget(
-            label=_("Enable AR Specifications"),
+            label=_("Enable Analysis Specifications"),
             description=_(
                 "Analysis specifications which are edited directly on the "
                 "Analysis Request."),
@@ -361,7 +361,7 @@ schema = BikaFolderSchema.copy() + Schema((
         default='ar_specs',
         vocabulary=DEFAULT_AR_SPECS,
         widget=SelectionWidget(
-            label=_("Default AR Specifications"),
+            label=_("Default Analysis Specifications"),
             description=_(
                 "Choose the default specifications used for all AR views "
                 "to display alerts and notifications.  These will also be "

--- a/bika/lims/docs/AnalysisRequestsSpecifications.rst
+++ b/bika/lims/docs/AnalysisRequestsSpecifications.rst
@@ -1,0 +1,147 @@
+Analysis Requests Specifications
+================================
+
+Analysis Requests in Bika LIMS describe an Analysis Order from a Client to the
+Laboratory. Analysis Specifications can be enabled/disabled on the 
+Bika Setup Analyses Tab on Enable Analysis Specifications field
+When the Enable Analysis Specifications is enabled, each Analysis can have 
+3 Types of Default Specification 
+1. Analysis Request Specification
+2. Sample Type Specifications (Lab)
+3. Sample Type Specifications (Client)
+
+Running this test from the buildout directory::
+
+    bin/test test_textual_doctests -t AnalysisRequestsSpecifications
+
+
+Test Setup
+----------
+
+Needed Imports::
+
+    >>> import transaction
+    >>> from DateTime import DateTime
+    >>> from plone import api as ploneapi
+
+    >>> from bika.lims import api
+    >>> from bika.lims.utils.analysisrequest import create_analysisrequest
+
+Functional Helpers::
+
+    >>> def start_server():
+    ...     from Testing.ZopeTestCase.utils import startZServer
+    ...     ip, port = startZServer()
+    ...     return "http://{}:{}/{}".format(ip, port, portal.id)
+
+    >>> def timestamp(format="%Y-%m-%d"):
+    ...     return DateTime().strftime(format)
+
+Variables::
+
+    >>> date_now = timestamp()
+    >>> portal = self.portal
+    >>> request = self.request
+    >>> bika_setup = portal.bika_setup
+    >>> bika_sampletypes = bika_setup.bika_sampletypes
+    >>> bika_samplepoints = bika_setup.bika_samplepoints
+    >>> bika_analysiscategories = bika_setup.bika_analysiscategories
+    >>> bika_analysisservices = bika_setup.bika_analysisservices
+    >>> bika_labcontacts = bika_setup.bika_labcontacts
+    >>> bika_storagelocations = bika_setup.bika_storagelocations
+    >>> bika_samplingdeviations = bika_setup.bika_samplingdeviations
+    >>> bika_sampleconditions = bika_setup.bika_sampleconditions
+    >>> portal_url = portal.absolute_url()
+    >>> bika_setup_url = portal_url + "/bika_setup"
+    >>> browser = self.getBrowser()
+
+
+Analysis Requests (AR)
+----------------------
+
+An `AnalysisRequest` can only be created inside a `Client`::
+
+    >>> clients = self.portal.clients
+    >>> client = api.create(clients, "Client", Name="RIDING BYTES", ClientID="RB")
+    >>> client
+    <Client at /plone/clients/client-1>
+
+To create a new AR, a `Contact` is needed::
+
+    >>> contact = api.create(client, "Contact", Firstname="Ramon", Surname="Bartl")
+    >>> contact
+    <Contact at /plone/clients/client-1/contact-1>
+
+A `SampleType` defines how long the sample can be retained, the minimum volume
+needed, if it is hazardous or not, the point where the sample was taken etc.::
+
+    >>> sampletype = api.create(bika_sampletypes, "SampleType", Prefix="water", MinimumVolume="100 ml")
+    >>> sampletype
+    <SampleType at /plone/bika_setup/bika_sampletypes/sampletype-1>
+
+A `SamplePoint` defines the location, where a `Sample` was taken::
+
+    >>> samplepoint = api.create(bika_samplepoints, "SamplePoint", title="Lake of Constance")
+    >>> samplepoint
+    <SamplePoint at /plone/bika_setup/bika_samplepoints/samplepoint-1>
+
+An `AnalysisCategory` categorizes different `AnalysisServices`::
+
+    >>> analysiscategory = api.create(bika_analysiscategories, "AnalysisCategory", title="Water")
+    >>> analysiscategory
+    <AnalysisCategory at /plone/bika_setup/bika_analysiscategories/analysiscategory-1>
+
+An `AnalysisService` defines a analysis service offered by the laboratory::
+
+    >>> analysisservice = api.create(bika_analysisservices, "AnalysisService", title="PH", ShortTitle="ph", Category=analysiscategory, Keyword="PH")
+    >>> analysisservice
+    <AnalysisService at /plone/bika_setup/bika_analysisservices/analysisservice-1>
+
+Set, the `EnableAnalysisSpecifications` and test if it's on the add form::
+Switch on::
+    >>> bika_setup.setEnableARSpecs(True)
+    >>> transaction.commit()
+    >>> bika_setup.getEnableARSpecs()
+    True
+    >>> create_ar_url = client.absolute_url() + '/ar_add?ar_count=1'
+    >>> browser.open(create_ar_url)
+    >>> browser.contents.count('Analysis Specification')
+    2
+
+Switch off::
+    >>> bika_setup.setEnableARSpecs(False)
+    >>> transaction.commit()
+    >>> bika_setup.getEnableARSpecs()
+    False
+    >>> create_ar_url = client.absolute_url() + '/ar_add?ar_count=1'
+    >>> browser.open(create_ar_url)
+    >>> browser.contents.count('Analysis Specification')
+    1
+
+Finally, the `AnalysisRequest` can be created::
+
+    >>> values = {
+    ...           'Client': client,
+    ...           'Contact': contact,
+    ...           'SamplingDate': date_now,
+    ...           'DateSampled': date_now,
+    ...           'SampleType': sampletype
+    ...          }
+
+    >>> service_uids = [analysisservice.UID()]
+    >>> ar = create_analysisrequest(client, request, values, service_uids)
+    >>> transaction.commit()
+    >>> ar
+    <AnalysisRequest at /plone/clients/client-1/water-0001-R01>
+    >>> ar_url = ar.absolute_url() + '/base_view'
+    >>> browser.open(ar_url)
+    >>> browser.contents.count('Analysis Specification')
+    2
+    >>> bika_setup.setEnableARSpecs(True)
+    >>> transaction.commit()
+    >>> bika_setup.getEnableARSpecs()
+    True
+    >>> ar_url = ar.absolute_url() + '/base_view'
+    >>> browser.open(ar_url)
+    >>> browser.contents.count('Analysis Specification')
+    3

--- a/bika/lims/tests/test_textual_doctests.py
+++ b/bika/lims/tests/test_textual_doctests.py
@@ -23,6 +23,7 @@ DOCTESTS = [
     "../docs/Instruments.rst",
     "../docs/Versioning.rst",
     "../docs/AnalysisRequests.rst",
+    "../docs/AnalysisRequestsSpecifications.rst",
     "../docs/Calculations.rst",
     "../docs/IDServer.rst",
     "../docs/Rolemap.rst",

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.4.0 (unreleased)
 ------------------
 
+- AN-155: Dormant Specifications are used. Even if Specifications are all off
 - Issue-2268: Show the Unit in Manage Analyses View
 - BC-147: Default empty WS view should list on due date
 - Issue-2103: WS Templates not offered for selection


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

https://jira.bikalabs.com/browse/AN-155

## Current behavior before PR
   Dormant Specifications are used. Even if Specifications are all off
## Desired behavior after PR is merged
    When Enable Analysis Specifications is disabled/off
        Hide the Specification column from Analyses table on AR View 
        On the AR add form and on the edit view, hide the Analysis Specification field

    When Enable Analysis Specifications is enabled/on
        Don't use inactive/dormant specifications
        Show the Specification column from Analyses table on AR View
        On the AR add form user Default Analysis Specifications that are choosen on the Bika Setup Tab,
        like Sample Type Specifications(Lab) for example
     
--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
