### PR TITLE
AN-145 initialise batch title field empty

### DIFF
--- a/bika/lims/content/batch.py
+++ b/bika/lims/content/batch.py
@@ -222,9 +222,12 @@ class Batch(ATFolder):
     def Title(self):
         """ Return the Batch ID if title is not defined """
         titlefield = self.Schema().getField('title')
-        if titlefield.widget.visible:
+        titlevalue = titlefield.get(self)
+        if titlefield.widget.visible and titlevalue:
             return safe_unicode(self.title).encode('utf-8')
         else:
+            if self.id.startswith('batch.'):
+                return ''
             return safe_unicode(self.id).encode('utf-8')
 
     def _getCatalogTool(self):

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.4.0 (unreleased)
 ------------------
 
+- AN-145: Set Initial value of Batch Title to empty string
 - Issue-2268: Show the Unit in Manage Analyses View
 - BC-147: Default empty WS view should list on due date
 - Issue-2103: WS Templates not offered for selection


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
https://jira.bikalabs.com/browse/AN-145

## Current behavior before PR
     On the batchfolder(batch listing) the Batch Title is empty
## Desired behavior after PR is merged
     If Batch Title is not filled in it should have the same value as Batch ID

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
