### PR TITLE
Issue-2299: Fix low performance on retrieving analysis data

### DIFF
--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -407,7 +407,7 @@ class Analysis(BaseContent):
         Some silliness here, for premature indexing, when the service
         is not yet configured.
         """
-        if getattr(self, "_Title", None) is None:
+        if not getattr(self, "_Title", None):
             s = ""
             try:
                 s = self.getService()

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -330,6 +330,19 @@ class Analysis(BaseContent):
     displayContentsTab = False
     schema = schema
 
+    # Custom Analysis Getters
+    #
+    # N.B.: These copy the original values from the Analysis Service on first access.
+    #
+    # The values from a created analysis should never change and always be the
+    # same as the original attributes from the service in the according version.
+    #
+    # XXX: Set on get -> not good and shouldn't be done
+    #
+    #      I'm doing this here to fix the expensive calls to `getService` on
+    #      multiple places. The architecture on Analysis -> AnalysisService is
+    #      completely reworked in SENAITE (https://github.com/senaite/bika.lims)
+    #      which should supersede this code in near future.
     def getSortKey(self):
         if getattr(self, "_SortKey", None) is None:
             service = self.getService()
@@ -342,7 +355,6 @@ class Analysis(BaseContent):
             self._DepartmentUID = service.getDepartment().UID()
         return self._DepartmentUID
 
-    # Hard caching attributes coming from the Service
     def getKeyword(self):
         if getattr(self, "_Keyword", None) is None:
             self._Keyword = self.Schema().getField("Keyword").get(self)
@@ -372,6 +384,7 @@ class Analysis(BaseContent):
         if getattr(self, "_PointOfCapture", None) is None:
             self._PointOfCapture = self.Schema().getField("PointOfCapture").get(self)
         return self._PointOfCapture
+    # /Custom Analysis Getter
 
     def _getCatalogTool(self):
         from bika.lims.catalog import getCatalog

--- a/bika/lims/content/analysis.py
+++ b/bika/lims/content/analysis.py
@@ -69,19 +69,6 @@ from bika.lims.utils.analysis import get_significant_digits
 from bika.lims.workflow import getTransitionActor
 from bika.lims.workflow import skip
 
-from bika.lims import api
-from plone.memoize.volatile import cache
-from plone.memoize.volatile import DontCache
-
-
-def cache_key(method, self):
-    creation_flag = self.checkCreationFlag()
-    if creation_flag:
-        raise DontCache
-    uid = api.get_uid(self)
-    modified = self.modified().ISO8601()
-    return "{}-{}".format(uid, modified)
-
 
 @indexer(IAnalysis)
 def Priority(instance):
@@ -682,11 +669,6 @@ class Analysis(BaseContent):
             return self.getAnalysis().aq_parent.getSample()
         return self.aq_parent.getSample()
 
-    @cache(cache_key)
-    def getKeyword(self):
-        return self.getService().getKeyword()
-
-    @cache(cache_key)
     def getClientTitle(self):
         return self.aq_parent.aq_parent.Title()
 

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.4.0 (unreleased)
 ------------------
 
+- Issue-2299: Low performance on retrieving analysis data
 - Issue-2268: Show the Unit in Manage Analyses View
 - BC-147: Default empty WS view should list on due date
 - Issue-2103: WS Templates not offered for selection


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/bikalims/bika.lims/issues/2299

Please note:
From the perspective on an Analysis, the attributes originating from an AS in a certain version never change, because even if the AS was changed afterwards, it would get a new version where the Analysis wouldn't have access to.

## Current behavior before PR

The Analysis Service was looked up on all AS based attributes, which has a bad impact on the performance

## Desired behavior after PR is merged

AS based attributes are stored locally to avoid any further Service lookups.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
