### PR TITLE
Issue-2302: Fix UnicodeDecodeError if title field validator

### DIFF
--- a/bika/lims/exportimport/instruments/resultsimport.py
+++ b/bika/lims/exportimport/instruments/resultsimport.py
@@ -111,8 +111,7 @@ class InstrumentResultsFileParser(Logger):
         """
         count = 0
         for val in self.getRawResults().values():
-            for row in val:
-                count += len(val)
+            count += len(val)
         return count
 
     def getAnalysesTotalCount(self):

--- a/bika/lims/validators.py
+++ b/bika/lims/validators.py
@@ -123,7 +123,7 @@ class UniqueFieldValidator:
             parent_objects = map(api.get_object, catalog(catalog_query))
         elif field_index and field_index in catalog.indexes():
             # We use the field index to reduce the results list
-            catalog_query[field_index] = valuesafe_unicode(value)
+            catalog_query[field_index] = safe_unicode(value)
             parent_objects = map(api.get_object, catalog(catalog_query))
         else:
             # fall back to the objectValues :(

--- a/bika/lims/validators.py
+++ b/bika/lims/validators.py
@@ -19,6 +19,7 @@ from zope.interface import implements
 
 from bika.lims import api
 from bika.lims.utils import to_utf8
+from bika.lims.utils import safe_unicode
 from bika.lims import bikaMessageFactory as _
 
 
@@ -118,11 +119,11 @@ class UniqueFieldValidator:
         # likely very expensive if the parent object contains many objects
         if fieldname in catalog.indexes():
             # We use the fieldname as index to reduce the results list
-            catalog_query[fieldname] = value
+            catalog_query[fieldname] = safe_unicode(value)
             parent_objects = map(api.get_object, catalog(catalog_query))
         elif field_index and field_index in catalog.indexes():
             # We use the field index to reduce the results list
-            catalog_query[field_index] = value
+            catalog_query[field_index] = valuesafe_unicode(value)
             parent_objects = map(api.get_object, catalog(catalog_query))
         else:
             # fall back to the objectValues :(

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.4.0 (unreleased)
 ------------------
 
+- Issue-2302: UnicodeDecodeError if title field validator
 - Issue-2268: Show the Unit in Manage Analyses View
 - BC-147: Default empty WS view should list on due date
 - Issue-2103: WS Templates not offered for selection


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/bikalims/bika.lims/issues/2302

## Current behavior before PR

UnicodeDecodeError occurs when the Title contains unicode characters.

## Desired behavior after PR is merged

Title field is correctly validated

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
