### PR TITLE
Fixed TypeError in Analysis Specification category expansion

### DIFF
--- a/bika/lims/browser/templates/bika_listing_table_items.pt
+++ b/bika/lims/browser/templates/bika_listing_table_items.pt
@@ -409,7 +409,7 @@
 
           <span autocomplete="off"
                 tal:condition="python:not allow_edit"
-                tal:content="python:item[column]['value']"/>
+                tal:content="python:item[column]"/>
         </td>
       </tr>
     </tal:rangecomments>

--- a/bika/lims/setuphandlers.py
+++ b/bika/lims/setuphandlers.py
@@ -266,7 +266,7 @@ class BikaGenerator:
         mp(permissions.ModifyPortalContent, ['Manager', 'LabManager', 'LabClerk', 'Owner'], 0)
         mp(ManageClients, ['Manager', 'LabManager', 'LabClerk'], 0)
         mp(permissions.AddPortalContent, ['Manager', 'LabManager', 'LabClerk', 'Owner'], 0)
-        mp(AddAnalysisSpec, ['Manager', 'LabManager', 'Owner'], 0)
+        mp(AddAnalysisSpec, ['Manager', 'LabManager', 'LabClerk', 'Owner'], 0)
         portal.clients.reindexObject()
 
         # We have to manually set the permissions of Contacts according to

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.4.0 (unreleased)
 ------------------
 
+- Issue-2304: Bika Listing for Analysis Specifications fails on category expansion
 - Issue-2302: UnicodeDecodeError if title field validator
 - Issue-2299: Low performance on retrieving analysis data
 - Issue-2268: Show the Unit in Manage Analyses View


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/bikalims/bika.lims/issues/2304

## Current behavior before PR

TypeError occurs

## Desired behavior after PR is merged

Category get expanded

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
