### PR TITLE
do not use localized date for chart js.

### DIFF
--- a/bika/lims/browser/referencesample.py
+++ b/bika/lims/browser/referencesample.py
@@ -167,6 +167,7 @@ class ReferenceAnalysesView(AnalysesView):
         # they are not actually used in the table rendering.
         item['Keyword'] = service.getKeyword()
         item['Unit'] = service.getUnit()
+        item['CapturedRaw'] = obj.getResultCaptureDate().strftime('%Y-%m-%d %I:%M %p')
 
         self.addToJSON(obj, service, item)
         return item
@@ -194,7 +195,7 @@ class ReferenceAnalysesView(AnalysesView):
             upper = smax + error_amount
             lower = smin - error_amount
 
-            anrow = {'date': item['Captured'],
+            anrow = {'date': item['CapturedRaw'],
                      'min': smin,
                      'max': smax,
                      'target': target,

--- a/bika/lims/browser/referencesample.py
+++ b/bika/lims/browser/referencesample.py
@@ -159,7 +159,8 @@ class ReferenceAnalysesView(AnalysesView):
         service = obj.getService()
         item['Category'] = service.getCategoryTitle()
         item['Service'] = service.Title()
-        item['Captured'] = self.ulocalized_time(obj.getResultCaptureDate())
+        capture_date = obj.getResultCaptureDate()
+        item['Captured'] = self.ulocalized_time(capture_date)
         brefs = obj.getBackReferences("WorksheetAnalysis")
         item['Worksheet'] = brefs and brefs[0].Title() or ''
         # The following item keywords are required for the
@@ -167,7 +168,7 @@ class ReferenceAnalysesView(AnalysesView):
         # they are not actually used in the table rendering.
         item['Keyword'] = service.getKeyword()
         item['Unit'] = service.getUnit()
-        item['CapturedRaw'] = obj.getResultCaptureDate().strftime('%Y-%m-%d %I:%M %p')
+        item['CapturedRaw'] = capture_date and capture_date.strftime('%Y-%m-%d %I:%M %p') or ''
 
         self.addToJSON(obj, service, item)
         return item


### PR DESCRIPTION
Do not use localized dates for control chart as it breaks the controlchart.js datetime parser.

bika.lims.graphics.controlchart.js
// Convert values to floats
// "2014-02-19 03:11 PM"
x_data_parse = d3.time.format("%Y-%m-%d %I:%M %p").parse;
