### PR TITLE
Issue-2308: Added contentsMethod methods to instrument listing views

### DIFF
--- a/bika/lims/browser/instrument.py
+++ b/bika/lims/browser/instrument.py
@@ -97,6 +97,9 @@ class InstrumentMaintenanceView(BikaListingView):
                          'getMaintainer']},
         ]
 
+    def contentsMethod(self, *args, **kw):
+        return self.context.getMaintenanceTasks()
+
     def folderitems(self):
         items = BikaListingView.folderitems(self)
         outitems = []
@@ -173,6 +176,9 @@ class InstrumentCalibrationsView(BikaListingView):
                          'getCalibrator']},
         ]
 
+    def contentsMethod(self, *args, **kw):
+        return self.context.getCalibrations()
+
     def folderitems(self):
         items = BikaListingView.folderitems(self)
         outitems = []
@@ -229,6 +235,9 @@ class InstrumentValidationsView(BikaListingView):
                          'getDownTo',
                          'getValidator']},
         ]
+
+    def contentsMethod(self, *args, **kw):
+        return self.context.getValidations()
 
     def folderitems(self):
         items = BikaListingView.folderitems(self)
@@ -310,6 +319,9 @@ class InstrumentScheduleView(BikaListingView):
                          'creator',
                          'created']},
         ]
+
+    def contentsMethod(self, *args, **kw):
+        return self.context.getSchedule()
 
     def folderitems(self):
         items = BikaListingView.folderitems(self)

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.4.0 (unreleased)
 ------------------
 
+- Issue-2308: Folderitems methods of Instrument Calibrations, Certifications and Validations are missing some objects
 - Issue-2304: Bika Listing for Analysis Specifications fails on category expansion
 - Issue-2302: UnicodeDecodeError if title field validator
 - Issue-2299: Low performance on retrieving analysis data


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/bikalims/bika.lims/issues/2308

## Current behavior before PR

Some objects were missed in listings and unnecessary loops were done in the folderitems method.

## Desired behavior after PR is merged

Even temporary objects like `instrumentcalibration.2016-07-20.7846173955` were shown

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
