### PR TITLE
WIP: Fix ID Server to handle a flushed storage or existing IDs with t…

### DIFF
--- a/bika/lims/browser/idserver/configure.zcml
+++ b/bika/lims/browser/idserver/configure.zcml
@@ -5,11 +5,20 @@
 
   <browser:page
       for="*"
-      name="seed"
+      name="ng_seed"
       class="bika.lims.browser.idserver.view.IDServerView"
       attribute="seed"
       permission="cmf.ManagePortal"
       layer="bika.lims.interfaces.IBikaLIMS"
-    />
+      />
+
+  <browser:page
+      for="*"
+      name="ng_flush"
+      class="bika.lims.browser.idserver.view.IDServerView"
+      attribute="flush"
+      permission="cmf.ManagePortal"
+      layer="bika.lims.interfaces.IBikaLIMS"
+      />
 
 </configure>

--- a/bika/lims/browser/idserver/view.py
+++ b/bika/lims/browser/idserver/view.py
@@ -23,7 +23,7 @@ class IDServerView(BrowserView):
         seed = int(seed)
         if seed < 0:
             return 'Seed cannot be negative'
-        seed = seed - 1
+
         number_generator = getUtility(INumberGenerator)
         new_seq = number_generator.set_number(key=prefix, value=seed)
         return 'IDServerView: "%s" seeded to %s' % (prefix, new_seq)

--- a/bika/lims/browser/idserver/view.py
+++ b/bika/lims/browser/idserver/view.py
@@ -1,3 +1,5 @@
+# -*- coding: utf-8 -*-
+
 from bika.lims.browser import BrowserView
 from bika.lims.numbergenerator import INumberGenerator
 from zope.component import getUtility
@@ -27,3 +29,10 @@ class IDServerView(BrowserView):
         number_generator = getUtility(INumberGenerator)
         new_seq = number_generator.set_number(key=prefix, value=seed)
         return 'IDServerView: "%s" seeded to %s' % (prefix, new_seq)
+
+    def flush(self):
+        """ Flush the storage
+        """
+        number_generator = getUtility(INumberGenerator)
+        number_generator.flush()
+        return "IDServerView: Number storage flushed!"

--- a/bika/lims/docs/IDServer.rst
+++ b/bika/lims/docs/IDServer.rst
@@ -246,7 +246,9 @@ Change ID formats and create new `AnalysisRequest`::
 Re-seed and create a new `Batch`::
     >>> ploneapi.user.grant_roles(user=current_user,roles = ['Manager'])
     >>> transaction.commit()
-    >>> browser.open(portal_url + '/seed?prefix=batch-BA&seed=10')
+    >>> browser.open(portal_url + '/ng_seed?prefix=batch-BA&seed=10')
     >>> batch = api.create(batches, "Batch", ClientID="RB")
     >>> batch.getId() == "BA-{}-0011".format(year)
     True
+
+TODO: Test the case when numbers are exhausted in a sequence!

--- a/bika/lims/docs/IDServer.rst
+++ b/bika/lims/docs/IDServer.rst
@@ -133,7 +133,7 @@ Set up `ID Server` configuration::
     ...             'portal_type': 'SamplePartition',
     ...             'sequence_type': 'counter',
     ...             'value': ''},
-    ...            {'form': 'BÖ-{year}-{seq:04d}',
+    ...            {'form': 'BA-{year}-{seq:04d}',
     ...             'portal_type': 'Batch',
     ...             'prefix': 'batch',
     ...             'sequence_type': 'generated',
@@ -220,7 +220,7 @@ Change ID formats and create new `AnalysisRequest`::
     ...             'portal_type': 'SamplePartition',
     ...             'sequence_type': 'counter',
     ...             'value': ''},
-    ...            {'form': 'BÖ-{year}-{seq:04d}',
+    ...            {'form': 'BA-{year}-{seq:04d}',
     ...             'portal_type': 'Batch',
     ...             'prefix': 'batch',
     ...             'sequence_type': 'generated',
@@ -250,4 +250,3 @@ Re-seed and create a new `Batch`::
     >>> batch = api.create(batches, "Batch", ClientID="RB")
     >>> batch.getId() == "BA-{}-0011".format(year)
     True
-

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -275,7 +275,7 @@ def get_generated_number(context, config, variables, **kw):
     if prefix:
         key = "{}-{}".format(key, prefix)
 
-    # XXX: Handle flushed storage - WIP!
+    # XXX: Handle flushed storage - refactoring needed here!
     if key not in number_generator:
         # we need to figure out the current state of the DB.
         existing = search_by_prefix(portal_type, prefix)
@@ -286,6 +286,10 @@ def get_generated_number(context, config, variables, **kw):
                 max_num = num
         # set the number generator
         number_generator.set_number(key, max_num)
+
+    # TODO: We need a way to figure out the max numbers allowed in this
+    # sequence to raise a KeyError when the current number exceeds the maximum
+    # number possible in the sequence
 
     # generate a new number
     number = number_generator.generate_number(key=key)

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -284,15 +284,12 @@ def get_generated_number(context, config, variables, **kw):
             num = to_int(slice(api.get_id(brain), start=split_length))
             if num > max_num:
                 max_num = num
-        # XXX why this?
-        max_num = max_num - 1
         # set the number generator
         number_generator.set_number(key, max_num)
 
     # generate a new number
     number = number_generator.generate_number(key=key)
-    # XXX here again
-    return number + 1
+    return number
 
 
 def generateUniqueId(context, **kw):

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -291,8 +291,13 @@ def get_generated_number(context, config, variables, **kw):
     # sequence to raise a KeyError when the current number exceeds the maximum
     # number possible in the sequence
 
-    # generate a new number
-    number = number_generator.generate_number(key=key)
+    # TODO: This allows us to "preview" the next generated ID in the UI
+    if not kw.get("dry_run", False):
+        # generate a new number
+        number = number_generator.generate_number(key=key)
+    else:
+        # just fetch the next number
+        number = number_generator.get(key, 1)
     return number
 
 
@@ -357,6 +362,11 @@ def renameAfterCreation(obj):
     if not new_id:
         new_id = generateUniqueId(obj)
 
+    # TODO: This is a naive check just in current folder
+    # -> this should check globally for duplicate objects with same prefix
+    # N.B. a check like `search_by_prefix` each time would probably slow things
+    # down too much!
+    # -> A solution could be to store all IDs with a certain prefix in a storage.
     parent = api.get_parent(obj)
     if new_id in parent.objectIds():
         # XXX We could do the check in a `while` loop and generate a new one.

--- a/bika/lims/numbergenerator.py
+++ b/bika/lims/numbergenerator.py
@@ -88,7 +88,7 @@ class NumberGenerator(object):
                 counter = storage[key]
                 storage[key] = counter + 1
             except KeyError:
-                storage[key] = 0
+                storage[key] = 1
         finally:
             logger.debug("*** consecutive number lock release ***")
             self.storage._p_changed = True

--- a/bika/lims/numbergenerator.py
+++ b/bika/lims/numbergenerator.py
@@ -88,7 +88,7 @@ class NumberGenerator(object):
                 counter = storage[key]
                 storage[key] = counter + 1
             except KeyError:
-                storage[key] = 1
+                storage[key] = 0
         finally:
             logger.debug("*** consecutive number lock release ***")
             self.storage._p_changed = True

--- a/bika/lims/numbergenerator.py
+++ b/bika/lims/numbergenerator.py
@@ -69,6 +69,12 @@ class NumberGenerator(object):
             out.append(value)
         return out
 
+    def __iter__(self):
+        return self.storage.__iter__()
+
+    def __getitem__(self, key):
+        return self.storage.__getitem__(key)
+
     def get_number(self, key):
         """ get the next consecutive number
         """
@@ -82,7 +88,7 @@ class NumberGenerator(object):
                 counter = storage[key]
                 storage[key] = counter + 1
             except KeyError:
-                storage[key] = 0
+                storage[key] = 1
         finally:
             logger.debug("*** consecutive number lock release ***")
             self.storage._p_changed = True
@@ -117,5 +123,3 @@ class NumberGenerator(object):
 
     def __call__(self, key="default"):
         return self.generate_number(key)
-
-

--- a/bika/lims/numbergenerator.py
+++ b/bika/lims/numbergenerator.py
@@ -75,6 +75,9 @@ class NumberGenerator(object):
     def __getitem__(self, key):
         return self.storage.__getitem__(key)
 
+    def get(self, key, default=None):
+        return self.storage.get(key, default)
+
     def get_number(self, key):
         """ get the next consecutive number
         """


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/bikalims/bika.lims/issues/2310

## Current behavior before PR

ID Server ignores contents with the same prefix and generates non-unique IDs

## Desired behavior after PR is merged

ID Server handles a flushed storage / or new storage keys for the same ID prefix gracefully.

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
