### PR TITLE
IDServer: Fixed default split length value

### DIFF
--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -261,7 +261,7 @@ def get_generated_number(context, config, variables, **kw):
     id_template = config.get("form", "")
 
     # The split length defines where the variable part of the ID template begins
-    split_length = config.get("split_length", 0)
+    split_length = config.get("split_length", 1)
 
     # The prefix tempalte is the static part of the ID
     prefix_template = slice(id_template, end=split_length)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/bikalims/bika.lims/issues/2310

This is a post-fixture for PR: https://github.com/bikalims/bika.lims/pull/2311.

## Current behavior before PR

If the Number Generator Storage was flushed, the code to figure out the starting point for the sequence returned 0 for non-configure content types like e.g. `Client`

## Desired behavior after PR is merged

The start of the sequence is calculated correctly

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
