### PR TITLE
UniqueFieldValidator: Encode value to utf-8 before passing it to the catalog

### DIFF
--- a/bika/lims/validators.py
+++ b/bika/lims/validators.py
@@ -119,11 +119,11 @@ class UniqueFieldValidator:
         # likely very expensive if the parent object contains many objects
         if fieldname in catalog.indexes():
             # We use the fieldname as index to reduce the results list
-            catalog_query[fieldname] = safe_unicode(value)
+            catalog_query[fieldname] = to_utf8(safe_unicode(value))
             parent_objects = map(api.get_object, catalog(catalog_query))
         elif field_index and field_index in catalog.indexes():
             # We use the field index to reduce the results list
-            catalog_query[field_index] = safe_unicode(value)
+            catalog_query[field_index] = to_utf8(safe_unicode(value))
             parent_objects = map(api.get_object, catalog(catalog_query))
         else:
             # fall back to the objectValues :(


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/bikalims/bika.lims/issues/2302

This is a post fixture for PR: https://github.com/bikalims/bika.lims/pull/2303

## Current behavior before PR

Cannot create a new Client, because the UniqueFieldValidator produces an `UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 1: ordinal not in range(128)`

## Desired behavior after PR is merged

Unique field validation works

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
