### PR TITLE
AR Add Form: Pass error messages to the frontend

### DIFF
--- a/bika/lims/browser/js/bika.lims.analysisrequest.add.js
+++ b/bika/lims/browser/js/bika.lims.analysisrequest.add.js
@@ -1328,14 +1328,17 @@
          */
         var ars, destination, errorbox, field, fieldname, message, msg, parent, q, stickertemplate;
         if (data['errors']) {
-          msg = '';
-          for (fieldname in data.errors) {
+          msg = data.errors.message;
+          if (msg !== "") {
+            msg = msg + "<br/>";
+          }
+          for (fieldname in data.errors.fielderrors) {
             field = $("#" + fieldname);
             parent = field.parent("div.field");
             if (field && parent) {
               parent.toggleClass("error");
               errorbox = parent.children("div.fieldErrorBox");
-              message = data.errors[fieldname];
+              message = data.errors.fielderrors[fieldname];
               errorbox.text(message);
               msg += message + "<br/>";
             }

--- a/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
+++ b/bika/lims/browser/js/coffee/bika.lims.analysisrequest.add.coffee
@@ -1447,14 +1447,17 @@ class window.AnalysisRequestAdd
       ###
 
       if data['errors']
-        msg = ''
-        for fieldname of data.errors
+        msg = data.errors.message
+        if msg isnt ""
+          msg = "#{msg}<br/>"
+
+        for fieldname of data.errors.fielderrors
           field = $("##{fieldname}")
           parent = field.parent "div.field"
           if field and parent
             parent.toggleClass "error"
             errorbox = parent.children("div.fieldErrorBox")
-            message = data.errors[fieldname]
+            message = data.errors.fielderrors[fieldname]
             errorbox.text message
             msg += "#{message}<br/>"
 

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.4.0 (unreleased)
 ------------------
 
+- Issue-2316: AR Add fails silently if e.g. the ID of the AR was already taken
 - Issue-2308: Folderitems methods of Instrument Calibrations, Certifications and Validations are missing some objects
 - Issue-2304: Bika Listing for Analysis Specifications fails on category expansion
 - Issue-2302: UnicodeDecodeError if title field validator


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/bikalims/bika.lims/issues/2316

## Current behavior before PR

No error message is shown in the AR Add Form

## Desired behavior after PR is merged

Error message is shown in the AR Add form if the AR couldn't be created

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
