### PR TITLE
AR Add: Skip Analyses in disabled categories

### DIFF
--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -524,7 +524,8 @@ class AnalysisRequestAddView(BrowserView):
 
         for brain in services:
             category = brain.getCategoryTitle
-            analyses[category].append(brain)
+            if category in analyses:
+                analyses[category].append(brain)
         return analyses
 
     @cache(cache_key)

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.4.0 (unreleased)
 ------------------
 
+- Issue-2317: AR Add fails if an Analysis Category was disabled
 - Issue-2316: AR Add fails silently if e.g. the ID of the AR was already taken
 - Issue-2308: Folderitems methods of Instrument Calibrations, Certifications and Validations are missing some objects
 - Issue-2304: Bika Listing for Analysis Specifications fails on category expansion


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/bikalims/bika.lims/issues/2317

## Current behavior before PR

AR Add form fails if an Analysis Category was disabled

## Desired behavior after PR is merged

AR Add does not show services in disabled Analysis Categories

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
