### PR TITLE
Fixed missing Client information in AR Add form when coming from AR listing view

### DIFF
--- a/bika/lims/browser/analysisrequest/add2.py
+++ b/bika/lims/browser/analysisrequest/add2.py
@@ -1103,7 +1103,7 @@ class ajaxAnalysisRequestAddView(AnalysisRequestAddView):
 
         # client
         client = self.get_client()
-        client_uid = api.get_uid(client)
+        client_uid = client and api.get_uid(client) or ""
 
         # sample matrix
         sample_matrix = obj.getSampleMatrix()

--- a/docs/CHANGELOG.txt
+++ b/docs/CHANGELOG.txt
@@ -1,6 +1,7 @@
 3.4.0 (unreleased)
 ------------------
 
+- Issue-2320: AR Add: Copy of multiple ARs from different clients raises a Traceback in the background
 - Issue-2317: AR Add fails if an Analysis Category was disabled
 - Issue-2316: AR Add fails silently if e.g. the ID of the AR was already taken
 - Issue-2308: Folderitems methods of Instrument Calibrations, Certifications and Validations are missing some objects


### PR DESCRIPTION
## Description of the issue/feature this PR addresses

Linked issue: https://github.com/bikalims/bika.lims/issues/2320

## Current behavior before PR

Copy of multiple ARs from /analysisrequests view raises a Traceback in the background

## Desired behavior after PR is merged

No Traceback in the background on copy from /analysisrequests view

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
