### PR TITLE
NG flush breaks id server

### DIFF
--- a/bika/lims/docs/IDServer.rst
+++ b/bika/lims/docs/IDServer.rst
@@ -63,6 +63,7 @@ Variables::
     >>> bika_storagelocations = bika_setup.bika_storagelocations
     >>> bika_samplingdeviations = bika_setup.bika_samplingdeviations
     >>> bika_sampleconditions = bika_setup.bika_sampleconditions
+    >>> bika_containers = bika_setup.bika_containers
     >>> portal_url = portal.absolute_url()
     >>> bika_setup_url = portal_url + "/bika_setup"
     >>> browser = self.getBrowser()
@@ -254,5 +255,25 @@ Re-seed and create a new `Batch`::
     >>> ar = create_analysisrequest(client, request, values, service_uids)
     >>> ar.getId()
     'RB-20170131-water-0002-R001'
+    >>> batch = api.create(batches, "Batch", ClientID="RB")
+    >>> batch.getId()
+    'BA-17-0012'
+    >>> batch.getId() == "BA-{}-0012".format(year)
+    True
+
+Bika Setup
+----------
+A `Container` is a bika_setup type that must be tested::
+
+    >>> container = api.create(bika_containers, "Container", Name="Big Jar")
+    >>> container
+    <Container at /plone/bika_setup/bika_containers/container-1>
+    >>> container = api.create(bika_containers, "Container", Name="Small Jar")
+    >>> container
+    <Container at /plone/bika_setup/bika_containers/container-2>
+    >>> browser.open(portal_url + '/ng_flush')
+    >>> container = api.create(bika_containers, "Container", Name="Tiny Jar")
+    >>> container
+    <Container at /plone/bika_setup/bika_containers/container-3>
 
 TODO: Test the case when numbers are exhausted in a sequence!

--- a/bika/lims/docs/IDServer.rst
+++ b/bika/lims/docs/IDServer.rst
@@ -251,13 +251,12 @@ Re-seed and create a new `Batch`::
     >>> batch = api.create(batches, "Batch", ClientID="RB")
     >>> batch.getId() == "BA-{}-0011".format(year)
     True
+    >>> transaction.commit()
     >>> browser.open(portal_url + '/ng_flush')
     >>> ar = create_analysisrequest(client, request, values, service_uids)
     >>> ar.getId()
     'RB-20170131-water-0002-R001'
     >>> batch = api.create(batches, "Batch", ClientID="RB")
-    >>> batch.getId()
-    'BA-17-0012'
     >>> batch.getId() == "BA-{}-0012".format(year)
     True
 
@@ -271,6 +270,7 @@ A `Container` is a bika_setup type that must be tested::
     >>> container = api.create(bika_containers, "Container", Name="Small Jar")
     >>> container
     <Container at /plone/bika_setup/bika_containers/container-2>
+    >>> transaction.commit()
     >>> browser.open(portal_url + '/ng_flush')
     >>> container = api.create(bika_containers, "Container", Name="Tiny Jar")
     >>> container

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -209,11 +209,26 @@ def get_current_year():
     return DateTime().strftime("%Y")[2:]
 
 
+def search_catalogs(portal_type):
+    """Returns brains which share the same portal_type
+    """
+    catalog_names = ['portal_catalog', 'bika_setup_catalog', 'bika_catalog']
+    UIDs = []
+    all_brains = []
+    for catalog_name in catalog_names:
+        catalog = api.get_tool(catalog_name)
+        brains = catalog({"portal_type": portal_type})
+        for brain in brains:
+            if brain.UID not in UIDs:
+                all_brains.append(brain)
+                UIDs.append(brain.UID)
+    return all_brains
+
 def search_by_prefix(portal_type, prefix):
     """Returns brains which share the same portal_type and ID prefix
     """
-    catalog = api.get_tool("portal_catalog")
-    brains = catalog({"portal_type": portal_type})
+    # Get all brains for all catalogs for given portal type
+    brains = search_catalogs(portal_type)
     # Filter brains with the same ID prefix
     return filter(lambda brain: api.get_id(brain).startswith(prefix), brains)
 

--- a/bika/lims/idserver.py
+++ b/bika/lims/idserver.py
@@ -217,7 +217,7 @@ def search_catalogs(portal_type):
     all_brains = []
     for catalog_name in catalog_names:
         catalog = api.get_tool(catalog_name)
-        brains = catalog({"portal_type": portal_type})
+        brains = api.search({"portal_type": portal_type}, catalog=catalog_name)
         for brain in brains:
             if brain.UID not in UIDs:
                 all_brains.append(brain)


### PR DESCRIPTION
## Description of the issue/feature this PR addresses
Items in the bika_setup_catalog do not continue in sequence after flushing the number generator

Linked issue: https://github.com/bikalims/bika.lims/issues/2322

## Current behavior before PR
After a flush, BSC items get new IDs from 1 instead of the next in the sequence

## Desired behavior after PR is merged
All items continue in the sequence after ng_flush

--
I confirm I have tested this PR thoroughly and coded it according to [PEP8][1] standards.

[1]: https://www.python.org/dev/peps/pep-0008
